### PR TITLE
Fixed several issues preventing compilation on macOS

### DIFF
--- a/code/linalg.c
+++ b/code/linalg.c
@@ -124,7 +124,7 @@ bool linalg_invert_matrix(mp_float_t *data, size_t N) {
     }
     for(size_t m=0; m < N; m++){
         // this could be faster with ((c < epsilon) && (c > -epsilon))
-        if(abs(data[m*(N+1)]) < epsilon) {
+        if(fabs(data[m*(N+1)]) < epsilon) {
             m_del(mp_float_t, unit, N*N);
             return false;
         }
@@ -307,7 +307,7 @@ mp_obj_t linalg_det(mp_obj_t oin) {
     }
     mp_float_t c;
     for(size_t m=0; m < in->m-1; m++){
-        if(abs(tmp[m*(in->n+1)]) < epsilon) {
+        if(fabs(tmp[m*(in->n+1)]) < epsilon) {
             m_del(mp_float_t, tmp, in->n*in->n);
             return mp_obj_new_float(0.0);
         }
@@ -346,7 +346,7 @@ mp_obj_t linalg_eig(mp_obj_t oin) {
         for(size_t n=m+1; n < in->n; n++) {
             // compare entry (m, n) to (n, m)
             // TODO: this must probably be scaled!
-            if(epsilon < abs(array[m*in->n + n] - array[n*in->n + m])) {
+            if(epsilon < fabs(array[m*in->n + n] - array[n*in->n + m])) {
                 mp_raise_ValueError("input matrix is asymmetric");
             }
         }

--- a/code/ndarray.c
+++ b/code/ndarray.c
@@ -580,7 +580,7 @@ mp_obj_t ndarray_iternext(mp_obj_t self_in) {
     ndarray_obj_t *ndarray = MP_OBJ_TO_PTR(self->ndarray);
     // TODO: in numpy, ndarrays are iterated with respect to the first axis. 
     size_t iter_end = 0;
-    if((ndarray->m == 1)) {
+    if(ndarray->m == 1) {
         iter_end = ndarray->array->len;
     } else {
         iter_end = ndarray->m;
@@ -888,12 +888,12 @@ mp_obj_t ndarray_unary_op(mp_unary_op_t op, mp_obj_t self_in) {
                 return ndarray_copy(self_in);
             }
             ndarray = MP_OBJ_TO_PTR(ndarray_copy(self_in));
-            if((self->array->typecode == NDARRAY_INT8)) {
+            if(self->array->typecode == NDARRAY_INT8) {
                 int8_t *array = (int8_t *)ndarray->array->items;
                 for(size_t i=0; i < self->array->len; i++) {
                     if(array[i] < 0) array[i] = -array[i];
                 }
-            } else if((self->array->typecode == NDARRAY_INT16)) {
+            } else if(self->array->typecode == NDARRAY_INT16) {
                 int16_t *array = (int16_t *)ndarray->array->items;
                 for(size_t i=0; i < self->array->len; i++) {
                     if(array[i] < 0) array[i] = -array[i];

--- a/code/poly.c
+++ b/code/poly.c
@@ -89,8 +89,8 @@ mp_obj_t poly_polyfit(size_t  n_args, const mp_obj_t *args) {
     if(!object_is_nditerable(args[0])) {
         mp_raise_ValueError("input data must be an iterable");
     }
-    uint16_t lenx, leny;
-    uint8_t deg;
+    uint16_t lenx = 0, leny = 0;
+    uint8_t deg = 0;
     mp_float_t *x, *XT, *y, *prod;
 
     if(n_args == 2) { // only the y values are supplied


### PR DESCRIPTION
Using the original code, attempting to compile on macOS using `clang` would fail. There were three types of error that were raised:

 * In `ndarray.c` there were three occurrences of the condition of `if` statements being an equality comparison surrounded by double parentheses. This raises a warning (treated as an error due to compilation with `-Werror`) because use of double parentheses is a standard idiom for _suppressing_ the warning about use of an assignment in a condition. This was fixed by removing the excess parentheses.
 * In `linalg.c` there were three cases of `abs()` being called with a floating point value and the result being compared to a floating point value, even though `abs()` takes and returns `int` values. This was replaced with calls to `fabs` as used elsewhere in the same file.
 * In `poly.c` static control flow analysis complained about potential use of un-initialised variable (`deg` and `leny`). While manual analysis indicates that there is no path that allows the variables to be used in an uninitialised state, simply initialising the variables with 0 removed the static analysis issue without increasing code size.

With these three issues fixed the code compiles cleanly on macOS using `clang`.