### PR TITLE
ndarray: let memoryview(arr) work

### DIFF
--- a/code/ndarray.c
+++ b/code/ndarray.c
@@ -910,3 +910,9 @@ mp_obj_t ndarray_unary_op(mp_unary_op_t op, mp_obj_t self_in) {
         default: return MP_OBJ_NULL; // operator not supported
     }
 }
+
+mp_int_t ndarray_get_buffer(mp_obj_t self_in, mp_buffer_info_t *bufinfo, mp_uint_t flags) {
+    ndarray_obj_t *self = MP_OBJ_TO_PTR(self_in);
+    // buffer_p.get_buffer() returns zero for success, while mp_get_buffer returns true for success
+    return !mp_get_buffer(self->array, bufinfo, flags);
+}

--- a/code/ndarray.h
+++ b/code/ndarray.h
@@ -69,6 +69,8 @@ mp_obj_t ndarray_rawsize(mp_obj_t );
 mp_obj_t ndarray_flatten(size_t , const mp_obj_t *, mp_map_t *);
 mp_obj_t ndarray_asbytearray(mp_obj_t );
 
+mp_int_t ndarray_get_buffer(mp_obj_t obj, mp_buffer_info_t *bufinfo, mp_uint_t flags);
+
 #define CREATE_SINGLE_ITEM(outarray, type, typecode, value) do {\
     ndarray_obj_t *tmp = create_new_ndarray(1, 1, (typecode));\
     type *tmparr = (type *)tmp->array->items;\

--- a/code/ulab.c
+++ b/code/ulab.c
@@ -59,6 +59,7 @@ const mp_obj_type_t ulab_ndarray_type = {
     .getiter = ndarray_getiter,
     .unary_op = ndarray_unary_op,
     .binary_op = ndarray_binary_op,
+    .buffer_p = { .get_buffer = ndarray_get_buffer, },
     .locals_dict = (mp_obj_dict_t*)&ulab_ndarray_locals_dict,
 };
 


### PR DESCRIPTION
.. this makes ndarray.rawbytes redundant.  Circuitpython will remove it.