### PR TITLE
Make portable to CircuitPython within same codebase

### DIFF
--- a/code/fft.c
+++ b/code/fft.c
@@ -78,11 +78,11 @@ void fft_kernel(mp_float_t *real, mp_float_t *imag, int n, int isign) {
 }
 
 mp_obj_t fft_fft_ifft_spectrum(size_t n_args, mp_obj_t arg_re, mp_obj_t arg_im, uint8_t type) {
-    if(!mp_obj_is_type(arg_re, &ulab_ndarray_type)) {
+    if(!MP_OBJ_IS_TYPE(arg_re, &ulab_ndarray_type)) {
         mp_raise_NotImplementedError(translate("FFT is defined for ndarrays only"));
     } 
     if(n_args == 2) {
-        if(!mp_obj_is_type(arg_im, &ulab_ndarray_type)) {
+        if(!MP_OBJ_IS_TYPE(arg_im, &ulab_ndarray_type)) {
             mp_raise_NotImplementedError(translate("FFT is defined for ndarrays only"));
         }
     }

--- a/code/filter.c
+++ b/code/filter.c
@@ -20,14 +20,14 @@
 #if ULAB_FILTER_CONVOLVE
 mp_obj_t filter_convolve(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     static const mp_arg_t allowed_args[] = {
-        { MP_QSTR_a, MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_rom_obj = MP_ROM_NONE } },
-        { MP_QSTR_v, MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_rom_obj = MP_ROM_NONE } },
+        { MP_QSTR_a, MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_rom_obj = mp_const_none } },
+        { MP_QSTR_v, MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_rom_obj = mp_const_none } },
     };
 
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all(2, pos_args, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
-    if(!mp_obj_is_type(args[0].u_obj, &ulab_ndarray_type) || !mp_obj_is_type(args[1].u_obj, &ulab_ndarray_type)) {
+    if(!MP_OBJ_IS_TYPE(args[0].u_obj, &ulab_ndarray_type) || !MP_OBJ_IS_TYPE(args[1].u_obj, &ulab_ndarray_type)) {
         mp_raise_TypeError(translate("convolve arguments must be ndarrays"));
     }
 

--- a/code/filter.c
+++ b/code/filter.c
@@ -69,15 +69,10 @@ mp_obj_t filter_convolve(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_a
             int top_n = MIN(len_c, len_a - k);
             int bot_n = MAX(-k, 0);
             for(int n=bot_n; n<top_n; n++) {
-            mp_float_t* a_ptr = a_items + bot_n + k;
-            mp_float_t* a_end = a_ptr + (top_n - bot_n);
-            mp_float_t* c_ptr = c_items + len_c - bot_n - 1;
-            for(; a_ptr != a_end;) {
                 int idx_c = len_c - n - 1;
                 int idx_a = n+k;
                 mp_float_t ai = ndarray_get_float_value(a->array->items, a->array->typecode, idx_a);
                 mp_float_t ci = ndarray_get_float_value(c->array->items, c->array->typecode, idx_c);
-                }
                 accum += ai * ci;
             }
             *outptr++ = accum;

--- a/code/linalg.c
+++ b/code/linalg.c
@@ -56,7 +56,7 @@ MP_DEFINE_CONST_FUN_OBJ_1(linalg_transpose_obj, linalg_transpose);
 #if ULAB_LINALG_RESHAPE
 mp_obj_t linalg_reshape(mp_obj_t self_in, mp_obj_t shape) {
     ndarray_obj_t *self = MP_OBJ_TO_PTR(self_in);
-    if(!mp_obj_is_type(shape, &mp_type_tuple) || (MP_OBJ_SMALL_INT_VALUE(mp_obj_len_maybe(shape)) != 2)) {
+    if(!MP_OBJ_IS_TYPE(shape, &mp_type_tuple) || (MP_OBJ_SMALL_INT_VALUE(mp_obj_len_maybe(shape)) != 2)) {
         mp_raise_ValueError(translate("shape must be a 2-tuple"));
     }
 
@@ -82,20 +82,20 @@ MP_DEFINE_CONST_FUN_OBJ_2(linalg_reshape_obj, linalg_reshape);
 #if ULAB_LINALG_SIZE
 mp_obj_t linalg_size(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     static const mp_arg_t allowed_args[] = {
-        { MP_QSTR_, MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_rom_obj = MP_ROM_NONE } },
-        { MP_QSTR_axis, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_rom_obj = MP_ROM_NONE } },
+        { MP_QSTR_, MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_rom_obj = mp_const_none } },
+        { MP_QSTR_axis, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_rom_obj = mp_const_none } },
     };
 
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all(1, pos_args, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
-    if(!mp_obj_is_type(args[0].u_obj, &ulab_ndarray_type)) {
+    if(!MP_OBJ_IS_TYPE(args[0].u_obj, &ulab_ndarray_type)) {
         mp_raise_TypeError(translate("size is defined for ndarrays only"));
     } else {
         ndarray_obj_t *ndarray = MP_OBJ_TO_PTR(args[0].u_obj);
         if(args[1].u_obj == mp_const_none) {
             return mp_obj_new_int(ndarray->array->len);
-        } else if(mp_obj_is_int(args[1].u_obj)) {
+        } else if(MP_OBJ_IS_INT(args[1].u_obj)) {
             uint8_t ax = mp_obj_get_int(args[1].u_obj);
             if(ax == 0) {
                 if(ndarray->m == 1) {
@@ -168,11 +168,11 @@ bool linalg_invert_matrix(mp_float_t *data, size_t N) {
 #if ULAB_LINALG_INV
 mp_obj_t linalg_inv(mp_obj_t o_in) {
     // since inv is not a class method, we have to inspect the input argument first
-    if(!mp_obj_is_type(o_in, &ulab_ndarray_type)) {
+    if(!MP_OBJ_IS_TYPE(o_in, &ulab_ndarray_type)) {
         mp_raise_TypeError(translate("only ndarrays can be inverted"));
     }
     ndarray_obj_t *o = MP_OBJ_TO_PTR(o_in);
-    if(!mp_obj_is_type(o_in, &ulab_ndarray_type)) {
+    if(!MP_OBJ_IS_TYPE(o_in, &ulab_ndarray_type)) {
         mp_raise_TypeError(translate("only ndarray objects can be inverted"));
     }
     if(o->m != o->n) {
@@ -205,7 +205,7 @@ MP_DEFINE_CONST_FUN_OBJ_1(linalg_inv_obj, linalg_inv);
 #if ULAB_LINALG_DOT
 mp_obj_t linalg_dot(mp_obj_t _m1, mp_obj_t _m2) {
     // TODO: should the results be upcast?
-    if(!mp_obj_is_type(_m1, &ulab_ndarray_type) || !mp_obj_is_type(_m2, &ulab_ndarray_type)) {
+    if(!MP_OBJ_IS_TYPE(_m1, &ulab_ndarray_type) || !MP_OBJ_IS_TYPE(_m2, &ulab_ndarray_type)) {
         mp_raise_TypeError(translate("arguments must be ndarrays"));
     }
     ndarray_obj_t *m1 = MP_OBJ_TO_PTR(_m1);
@@ -246,14 +246,14 @@ mp_obj_t linalg_zeros_ones(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw
     mp_arg_parse_all(n_args, pos_args, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
     
     uint8_t dtype = args[1].u_int;
-    if(!mp_obj_is_int(args[0].u_obj) && !mp_obj_is_type(args[0].u_obj, &mp_type_tuple)) {
+    if(!MP_OBJ_IS_INT(args[0].u_obj) && !MP_OBJ_IS_TYPE(args[0].u_obj, &mp_type_tuple)) {
         mp_raise_TypeError(translate("input argument must be an integer or a 2-tuple"));
     }
     ndarray_obj_t *ndarray = NULL;
-    if(mp_obj_is_int(args[0].u_obj)) {
+    if(MP_OBJ_IS_INT(args[0].u_obj)) {
         size_t n = mp_obj_get_int(args[0].u_obj);
         ndarray = create_new_ndarray(1, n, dtype);
-    } else if(mp_obj_is_type(args[0].u_obj, &mp_type_tuple)) {
+    } else if(MP_OBJ_IS_TYPE(args[0].u_obj, &mp_type_tuple)) {
         mp_obj_tuple_t *tuple = MP_OBJ_TO_PTR(args[0].u_obj);
         if(tuple->len != 2) {
             mp_raise_TypeError(translate("input argument must be an integer or a 2-tuple"));
@@ -291,7 +291,7 @@ MP_DEFINE_CONST_FUN_OBJ_KW(linalg_ones_obj, 0, linalg_ones);
 mp_obj_t linalg_eye(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_, MP_ARG_REQUIRED | MP_ARG_INT, {.u_int = 0} },
-        { MP_QSTR_M, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_rom_obj = MP_ROM_NONE } },
+        { MP_QSTR_M, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_rom_obj = mp_const_none } },
         { MP_QSTR_k, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 0} },        
         { MP_QSTR_dtype, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = NDARRAY_FLOAT} },
     };
@@ -334,7 +334,7 @@ MP_DEFINE_CONST_FUN_OBJ_KW(linalg_eye_obj, 0, linalg_eye);
 
 #if ULAB_LINALG_DET
 mp_obj_t linalg_det(mp_obj_t oin) {
-    if(!mp_obj_is_type(oin, &ulab_ndarray_type)) {
+    if(!MP_OBJ_IS_TYPE(oin, &ulab_ndarray_type)) {
         mp_raise_TypeError(translate("function defined for ndarrays only"));
     }
     ndarray_obj_t *in = MP_OBJ_TO_PTR(oin);
@@ -375,7 +375,7 @@ MP_DEFINE_CONST_FUN_OBJ_1(linalg_det_obj, linalg_det);
 
 #if ULAB_LINALG_EIG
 mp_obj_t linalg_eig(mp_obj_t oin) {
-    if(!mp_obj_is_type(oin, &ulab_ndarray_type)) {
+    if(!MP_OBJ_IS_TYPE(oin, &ulab_ndarray_type)) {
         mp_raise_TypeError(translate("function defined for ndarrays only"));
     }
     ndarray_obj_t *in = MP_OBJ_TO_PTR(oin);

--- a/code/ndarray.h
+++ b/code/ndarray.h
@@ -58,7 +58,11 @@ void ndarray_assign_elements(mp_obj_array_t *, mp_obj_t , uint8_t , size_t *);
 ndarray_obj_t *create_new_ndarray(size_t , size_t , uint8_t );
 
 mp_obj_t ndarray_copy(mp_obj_t );
+#ifdef CIRCUITPY
+mp_obj_t ndarray_make_new(const mp_obj_type_t *type, size_t n_args, const mp_obj_t *args, mp_map_t *kw_args);
+#else
 mp_obj_t ndarray_make_new(const mp_obj_type_t *, size_t , size_t , const mp_obj_t *);
+#endif
 mp_obj_t ndarray_subscr(mp_obj_t , mp_obj_t , mp_obj_t );
 mp_obj_t ndarray_getiter(mp_obj_t , mp_obj_iter_buf_t *);
 mp_obj_t ndarray_binary_op(mp_binary_op_t , mp_obj_t , mp_obj_t );

--- a/code/numerical.c
+++ b/code/numerical.c
@@ -32,11 +32,11 @@ enum NUMERICAL_FUNCTION_TYPE {
 #if ULAB_NUMERICAL_LINSPACE
 mp_obj_t numerical_linspace(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     static const mp_arg_t allowed_args[] = {
-        { MP_QSTR_, MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_rom_obj = MP_ROM_NONE } },
-        { MP_QSTR_, MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_rom_obj = MP_ROM_NONE } },
+        { MP_QSTR_, MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_rom_obj = mp_const_none } },
+        { MP_QSTR_, MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_rom_obj = mp_const_none } },
         { MP_QSTR_num, MP_ARG_INT, {.u_int = 50} },
-        { MP_QSTR_endpoint, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_rom_obj = MP_ROM_TRUE} },
-        { MP_QSTR_retstep, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_rom_obj = MP_ROM_FALSE} },
+        { MP_QSTR_endpoint, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_rom_obj = mp_const_true} },
+        { MP_QSTR_retstep, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_rom_obj = mp_const_false} },
         { MP_QSTR_dtype, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = NDARRAY_FLOAT} },
     };
 
@@ -258,8 +258,8 @@ mp_obj_t numerical_argmin_argmax_ndarray(ndarray_obj_t *ndarray, mp_obj_t axis, 
 
 STATIC mp_obj_t numerical_function(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args, uint8_t optype) {
     static const mp_arg_t allowed_args[] = {
-        { MP_QSTR_, MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_rom_obj = MP_ROM_NONE} } ,
-        { MP_QSTR_axis, MP_ARG_OBJ, {.u_rom_obj = MP_ROM_NONE } },
+        { MP_QSTR_, MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_rom_obj = mp_const_none} } ,
+        { MP_QSTR_axis, MP_ARG_OBJ, {.u_rom_obj = mp_const_none } },
     };
 
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
@@ -344,8 +344,8 @@ MP_DEFINE_CONST_FUN_OBJ_KW(numerical_mean_obj, 1, numerical_mean);
 
 mp_obj_t numerical_std(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     static const mp_arg_t allowed_args[] = {
-        { MP_QSTR_, MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_rom_obj = MP_ROM_NONE } } ,
-        { MP_QSTR_axis, MP_ARG_OBJ, {.u_rom_obj = MP_ROM_NONE } },
+        { MP_QSTR_, MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_rom_obj = mp_const_none } } ,
+        { MP_QSTR_axis, MP_ARG_OBJ, {.u_rom_obj = mp_const_none } },
         { MP_QSTR_ddof, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 0} },
     };
 
@@ -375,9 +375,9 @@ MP_DEFINE_CONST_FUN_OBJ_KW(numerical_std_obj, 1, numerical_std);
 #if ULAB_NUMERICAL_ROLL
 mp_obj_t numerical_roll(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     static const mp_arg_t allowed_args[] = {
-        { MP_QSTR_, MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_rom_obj = MP_ROM_NONE  } },
-        { MP_QSTR_, MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_rom_obj = MP_ROM_NONE } },
-        { MP_QSTR_axis, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_rom_obj = MP_ROM_NONE } },
+        { MP_QSTR_, MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_rom_obj = mp_const_none  } },
+        { MP_QSTR_, MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_rom_obj = mp_const_none } },
+        { MP_QSTR_axis, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_rom_obj = mp_const_none } },
     };
 
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
@@ -459,14 +459,14 @@ MP_DEFINE_CONST_FUN_OBJ_KW(numerical_roll_obj, 2, numerical_roll);
 #if ULAB_NUMERICAL_FLIP
 mp_obj_t numerical_flip(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     static const mp_arg_t allowed_args[] = {
-        { MP_QSTR_, MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_rom_obj = MP_ROM_NONE } },
-        { MP_QSTR_axis, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_rom_obj = MP_ROM_NONE } },
+        { MP_QSTR_, MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_rom_obj = mp_const_none } },
+        { MP_QSTR_axis, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_rom_obj = mp_const_none } },
     };
 
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all(1, pos_args, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
     
-    if(!mp_obj_is_type(args[0].u_obj, &ulab_ndarray_type)) {
+    if(!MP_OBJ_IS_TYPE(args[0].u_obj, &ulab_ndarray_type)) {
         mp_raise_TypeError(translate("flip argument must be an ndarray"));
     }
     if((args[1].u_obj != mp_const_none) && 
@@ -510,7 +510,7 @@ MP_DEFINE_CONST_FUN_OBJ_KW(numerical_flip_obj, 1, numerical_flip);
 #if ULAB_NUMERICAL_DIFF
 mp_obj_t numerical_diff(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     static const mp_arg_t allowed_args[] = {
-        { MP_QSTR_, MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_rom_obj = MP_ROM_NONE } },
+        { MP_QSTR_, MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_rom_obj = mp_const_none } },
         { MP_QSTR_n, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = 1 } },
         { MP_QSTR_axis, MP_ARG_KW_ONLY | MP_ARG_INT, {.u_int = -1 } },
     };
@@ -518,7 +518,7 @@ mp_obj_t numerical_diff(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_ar
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all(1, pos_args, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
     
-    if(!mp_obj_is_type(args[0].u_obj, &ulab_ndarray_type)) {
+    if(!MP_OBJ_IS_TYPE(args[0].u_obj, &ulab_ndarray_type)) {
         mp_raise_TypeError(translate("diff argument must be an ndarray"));
     }
     
@@ -581,7 +581,7 @@ MP_DEFINE_CONST_FUN_OBJ_KW(numerical_diff_obj, 1, numerical_diff);
 
 #if ULAB_NUMERICAL_SORT
 mp_obj_t numerical_sort_helper(mp_obj_t oin, mp_obj_t axis, uint8_t inplace) {
-    if(!mp_obj_is_type(oin, &ulab_ndarray_type)) {
+    if(!MP_OBJ_IS_TYPE(oin, &ulab_ndarray_type)) {
         mp_raise_TypeError(translate("sort argument must be an ndarray"));
     }
 
@@ -639,7 +639,7 @@ mp_obj_t numerical_sort_helper(mp_obj_t oin, mp_obj_t axis, uint8_t inplace) {
 // numpy function
 mp_obj_t numerical_sort(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     static const mp_arg_t allowed_args[] = {
-        { MP_QSTR_, MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_rom_obj = MP_ROM_NONE } },
+        { MP_QSTR_, MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_rom_obj = mp_const_none } },
         { MP_QSTR_axis, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_int = -1 } },
     };
 
@@ -654,7 +654,7 @@ MP_DEFINE_CONST_FUN_OBJ_KW(numerical_sort_obj, 1, numerical_sort);
 // method of an ndarray
 mp_obj_t numerical_sort_inplace(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     static const mp_arg_t allowed_args[] = {
-        { MP_QSTR_, MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_rom_obj = MP_ROM_NONE } },
+        { MP_QSTR_, MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_rom_obj = mp_const_none } },
         { MP_QSTR_axis, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_int = -1 } },
     };
 
@@ -670,12 +670,12 @@ MP_DEFINE_CONST_FUN_OBJ_KW(numerical_sort_inplace_obj, 1, numerical_sort_inplace
 #if ULAB_NUMERICAL_ARGSORT
 mp_obj_t numerical_argsort(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     static const mp_arg_t allowed_args[] = {
-        { MP_QSTR_, MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_rom_obj = MP_ROM_NONE } },
+        { MP_QSTR_, MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_rom_obj = mp_const_none } },
         { MP_QSTR_axis, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_int = -1 } },
     };
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all(1, pos_args, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
-    if(!mp_obj_is_type(args[0].u_obj, &ulab_ndarray_type)) {
+    if(!MP_OBJ_IS_TYPE(args[0].u_obj, &ulab_ndarray_type)) {
         mp_raise_TypeError(translate("argsort argument must be an ndarray"));
     }
 

--- a/code/poly.c
+++ b/code/poly.c
@@ -18,17 +18,17 @@
 
 #if ULAB_POLY_POLYVAL || ULAB_POLY_POLYFIT
 bool object_is_nditerable(mp_obj_t o_in) {
-    if(mp_obj_is_type(o_in, &ulab_ndarray_type) || 
-      mp_obj_is_type(o_in, &mp_type_tuple) || 
-      mp_obj_is_type(o_in, &mp_type_list) || 
-      mp_obj_is_type(o_in, &mp_type_range)) {
+    if(MP_OBJ_IS_TYPE(o_in, &ulab_ndarray_type) || 
+      MP_OBJ_IS_TYPE(o_in, &mp_type_tuple) || 
+      MP_OBJ_IS_TYPE(o_in, &mp_type_list) || 
+      MP_OBJ_IS_TYPE(o_in, &mp_type_range)) {
         return true;
     }
     return false;
 }
 
 size_t get_nditerable_len(mp_obj_t o_in) {
-    if(mp_obj_is_type(o_in, &ulab_ndarray_type)) {
+    if(MP_OBJ_IS_TYPE(o_in, &ulab_ndarray_type)) {
         ndarray_obj_t *in = MP_OBJ_TO_PTR(o_in);
         return in->array->len;
     } else {
@@ -43,7 +43,7 @@ mp_obj_t poly_polyval(mp_obj_t o_p, mp_obj_t o_x) {
     // TODO: there is a bug here: matrices won't work, 
     // because there is a single iteration loop
     size_t m, n;
-    if(mp_obj_is_type(o_x, &ulab_ndarray_type)) {
+    if(MP_OBJ_IS_TYPE(o_x, &ulab_ndarray_type)) {
         ndarray_obj_t *ndx = MP_OBJ_TO_PTR(o_x);
         m = ndx->m;
         n = ndx->n;

--- a/code/vectorise.c
+++ b/code/vectorise.c
@@ -24,11 +24,11 @@
     
 mp_obj_t vectorise_generic_vector(mp_obj_t o_in, mp_float_t (*f)(mp_float_t)) {
     // Return a single value, if o_in is not iterable
-    if(mp_obj_is_float(o_in) || mp_obj_is_integer(o_in)) {
+    if(mp_obj_is_float(o_in) || MP_OBJ_IS_INT(o_in)) {
             return mp_obj_new_float(f(mp_obj_get_float(o_in)));
     }
     mp_float_t x;
-    if(mp_obj_is_type(o_in, &ulab_ndarray_type)) {
+    if(MP_OBJ_IS_TYPE(o_in, &ulab_ndarray_type)) {
         ndarray_obj_t *source = MP_OBJ_TO_PTR(o_in);
         ndarray_obj_t *ndarray = create_new_ndarray(source->m, source->n, NDARRAY_FLOAT);
         mp_float_t *dataout = (mp_float_t *)ndarray->array->items;
@@ -44,8 +44,8 @@ mp_obj_t vectorise_generic_vector(mp_obj_t o_in, mp_float_t (*f)(mp_float_t)) {
             ITERATE_VECTOR(mp_float_t, source, dataout);
         }
         return MP_OBJ_FROM_PTR(ndarray);
-    } else if(mp_obj_is_type(o_in, &mp_type_tuple) || mp_obj_is_type(o_in, &mp_type_list) || 
-        mp_obj_is_type(o_in, &mp_type_range)) { // i.e., the input is a generic iterable
+    } else if(MP_OBJ_IS_TYPE(o_in, &mp_type_tuple) || MP_OBJ_IS_TYPE(o_in, &mp_type_list) || 
+        MP_OBJ_IS_TYPE(o_in, &mp_type_range)) { // i.e., the input is a generic iterable
             mp_obj_array_t *o = MP_OBJ_TO_PTR(o_in);
             ndarray_obj_t *out = create_new_ndarray(1, o->len, NDARRAY_FLOAT);
             mp_float_t *dataout = (mp_float_t *)out->array->items;


### PR DESCRIPTION
Testing performed: Built both circuitpython (ulab PR branch, unix port) and micropython (master branch, unix port) with the same ulab sources.  Ran basic smoketest of creating an ndarray via the ulab.array constructor, including dtype keyword argument.