### PR TITLE
include only code changes in workflow file

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,10 +2,10 @@ name: Build CI
 
 on:
   push:
-	paths:
-	- 'code/'
-	- 'tests/'
-	- '.github/workflows/'
+    paths:
+    - 'code/'
+    - 'tests/'
+    - '.github/workflows/'
 
   pull_request:
   release:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,12 +2,11 @@ name: Build CI
 
 on:
   push:
+  pull_request:
     paths:
     - 'code/'
     - 'tests/'
     - '.github/workflows/'
-
-  pull_request:
   release:
     types: [published]
   check_suite:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,11 @@ name: Build CI
 
 on:
   push:
+	paths:
+	- 'code/'
+	- 'tests/'
+	- '.github/workflows/'
+
   pull_request:
   release:
     types: [published]


### PR DESCRIPTION
This PR modifies the workflow trigger, so that CI runs only, if files in either code/, or tests/ change. With that, updates to the documentation would not consume github resources. 