### PR TITLE
moved spectrum to extras module

### DIFF
--- a/code/extras.c
+++ b/code/extras.c
@@ -19,13 +19,24 @@
 
 #if ULAB_EXTRAS_MODULE
 
-STATIC const mp_rom_map_elem_t ulab_filter_globals_table[] = {
+mp_obj_t extras_spectrum(size_t n_args, const mp_obj_t *args) {
+    if(n_args == 2) {
+        return fft_fft_ifft_spectrum(n_args, args[0], args[1], FFT_SPECTRUM);
+    } else {
+        return fft_fft_ifft_spectrum(n_args, args[0], mp_const_none, FFT_SPECTRUM);
+    }
+}
+
+MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(extras_spectrum_obj, 1, 2, extras_spectrum);
+
+STATIC const mp_rom_map_elem_t ulab_extras_globals_table[] = {
     { MP_OBJ_NEW_QSTR(MP_QSTR___name__), MP_OBJ_NEW_QSTR(MP_QSTR_extras) },
+	{ MP_OBJ_NEW_QSTR(MP_QSTR_spectrum), (mp_obj_t)&extras_spectrum_obj },
 };
 
 STATIC MP_DEFINE_CONST_DICT(mp_module_ulab_extras_globals, ulab_extras_globals_table);
 
-mp_obj_module_t ulab_filter_module = {
+mp_obj_module_t ulab_extras_module = {
     .base = { &mp_type_module },
     .globals = (mp_obj_dict_t*)&mp_module_ulab_extras_globals,
 };

--- a/code/extras.h
+++ b/code/extras.h
@@ -14,6 +14,7 @@
 
 #include "ulab.h"
 #include "ndarray.h"
+#include "fft.h"
 
 #if ULAB_EXTRAS_MODULE
 

--- a/code/fft.c
+++ b/code/fft.c
@@ -23,12 +23,6 @@
 
 #if ULAB_FFT_MODULE
 
-enum FFT_TYPE {
-    FFT_FFT,
-    FFT_IFFT,
-    FFT_SPECTRUM,
-};
-
 void fft_kernel(mp_float_t *real, mp_float_t *imag, int n, int isign) {
     // This is basically a modification of four1 from Numerical Recipes
     // The main difference is that this function takes two arrays, one 
@@ -172,21 +166,10 @@ mp_obj_t fft_ifft(size_t n_args, const mp_obj_t *args) {
 
 MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(fft_ifft_obj, 1, 2, fft_ifft);
 
-mp_obj_t fft_spectrum(size_t n_args, const mp_obj_t *args) {
-    if(n_args == 2) {
-        return fft_fft_ifft_spectrum(n_args, args[0], args[1], FFT_SPECTRUM);
-    } else {
-        return fft_fft_ifft_spectrum(n_args, args[0], mp_const_none, FFT_SPECTRUM);
-    }
-}
-
-MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(fft_spectrum_obj, 1, 2, fft_spectrum);
-
 STATIC const mp_rom_map_elem_t ulab_fft_globals_table[] = {
     { MP_OBJ_NEW_QSTR(MP_QSTR___name__), MP_OBJ_NEW_QSTR(MP_QSTR_fft) },
     { MP_OBJ_NEW_QSTR(MP_QSTR_fft), (mp_obj_t)&fft_fft_obj },
     { MP_OBJ_NEW_QSTR(MP_QSTR_ifft), (mp_obj_t)&fft_ifft_obj },
-    { MP_OBJ_NEW_QSTR(MP_QSTR_spectrum), (mp_obj_t)&fft_spectrum_obj },
 };
 
 STATIC MP_DEFINE_CONST_DICT(mp_module_ulab_fft_globals, ulab_fft_globals_table);

--- a/code/fft.h
+++ b/code/fft.h
@@ -19,6 +19,12 @@
 
 #define SWAP(t, a, b) { t tmp = a; a = b; b = tmp; }
 
+enum FFT_TYPE {
+    FFT_FFT,
+    FFT_IFFT,
+    FFT_SPECTRUM,
+};
+
 #if ULAB_FFT_MODULE
 
 extern mp_obj_module_t ulab_fft_module;
@@ -26,6 +32,8 @@ extern mp_obj_module_t ulab_fft_module;
 MP_DECLARE_CONST_FUN_OBJ_VAR_BETWEEN(fft_fft_obj);
 MP_DECLARE_CONST_FUN_OBJ_VAR_BETWEEN(fft_ifft_obj);
 MP_DECLARE_CONST_FUN_OBJ_VAR_BETWEEN(fft_spectrum_obj);
+
+mp_obj_t fft_fft_ifft_spectrum(size_t , mp_obj_t , mp_obj_t , uint8_t );
 
 #endif
 #endif

--- a/code/linalg.h
+++ b/code/linalg.h
@@ -31,5 +31,11 @@ bool linalg_invert_matrix(mp_float_t *, size_t );
 
 extern mp_obj_module_t ulab_linalg_module;
 
+MP_DECLARE_CONST_FUN_OBJ_KW(linalg_size_obj);
+MP_DECLARE_CONST_FUN_OBJ_1(linalg_inv_obj);
+MP_DECLARE_CONST_FUN_OBJ_2(linalg_dot_obj);
+MP_DECLARE_CONST_FUN_OBJ_1(linalg_det_obj);
+MP_DECLARE_CONST_FUN_OBJ_1(linalg_eig_obj);
+
 #endif
 #endif

--- a/code/ulab.h
+++ b/code/ulab.h
@@ -34,6 +34,6 @@
 #define ULAB_FILTER_MODULE (1)
 
 // user-defined modules
-#define ULAB_EXTRAS_MODULE (0)
+#define ULAB_EXTRAS_MODULE (1)
 
 #endif


### PR DESCRIPTION
`spectrum` is moved from `fft` to the `extras` module. If `spectrum` is desired, `fft` must be included in `ulab.h`. @jepler can you suggest a more elegant separation (one that takes the dependence on `fft` automatically into account)?