### PR TITLE
slice_length: avoid implementation-defined division by negative number

### DIFF
--- a/code/ndarray.c
+++ b/code/ndarray.c
@@ -251,9 +251,9 @@ mp_obj_t ndarray_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw,
 #endif
 
 size_t slice_length(mp_bound_slice_t slice) {
-    int32_t len, correction = 1;
+    ssize_t len, correction = 1;
     if(slice.step > 0) correction = -1;
-    len = (slice.stop - slice.start + (slice.step + correction)) / slice.step;
+    len = (ssize_t)(slice.stop - slice.start + (slice.step + correction)) / slice.step;
     if(len < 0) return 0;
     return (size_t)len;
 }


### PR DESCRIPTION
In CircuitPython (only), a the slice assignment to [-1:-1:-3] of an ndarray of length 1 caused a crash.  This appears to be because in CircuitPython, the internal pointer of an empty array was NULL rather than pointing at some memory which happened to be valid and assignable.

This appears to be a corner case of how integer promotion rules work in C. The expression `slice.stop - slice.start + (slice.step + correction)` is type `unsigned long` and on a LP64 platform its value is 18446744073709551614.  This led to the function returning that this slice had length 1 instead, during the automated tests.

By casting to signed types capable of holding indices and sizes, the problem is corrected on both platforms.