### PR TITLE
added fast initialisation option to ndarray_make_new_core, and updated docs

### DIFF
--- a/code/ndarray.c
+++ b/code/ndarray.c
@@ -170,6 +170,9 @@ STATIC mp_obj_t ndarray_make_new_core(const mp_obj_type_t *type, size_t n_args, 
     
 	if(MP_OBJ_IS_TYPE(args[0], &ulab_ndarray_type)) {
 		ndarray_obj_t *ndarray = MP_OBJ_TO_PTR(args[0]);
+		if(dtype == ndarray->array->typecode) {
+			return ndarray_copy(args[0]);
+		}
 		ndarray_obj_t *ndarray_new = create_new_ndarray(ndarray->m, ndarray->n, dtype);
 		mp_obj_t item;
 		if((ndarray->array->typecode == NDARRAY_FLOAT) &&(dtype != NDARRAY_FLOAT)) {

--- a/code/ulab.c
+++ b/code/ulab.c
@@ -30,7 +30,7 @@
 #include "numerical.h"
 #include "extras.h"
 
-STATIC MP_DEFINE_STR_OBJ(ulab_version_obj, "0.38.0");
+STATIC MP_DEFINE_STR_OBJ(ulab_version_obj, "0.38.1");
 
 MP_DEFINE_CONST_FUN_OBJ_KW(ndarray_flatten_obj, 1, ndarray_flatten);
 

--- a/docs/manual/source/conf.py
+++ b/docs/manual/source/conf.py
@@ -22,7 +22,7 @@ copyright = '2019-2020, Zoltán Vörös'
 author = 'Zoltán Vörös'
 
 # The full version, including alpha/beta/rc tags
-release = '0.38.0'
+release = '0.38.1'
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/manual/source/ulab.rst
+++ b/docs/manual/source/ulab.rst
@@ -461,7 +461,8 @@ statement is almost trivial, since ``ndarray``\ s are iterables
 themselves, though it should be pointed out that initialising through
 arrays is faster, because simply a new copy is created, without
 inspection, iteration etc. It is also possible to coerce type conversion
-of the output:
+of the output (with type conversion, the iteration cannot be avoided,
+therefore, this case will always be slower than straight copying):
 
 .. code::
         
@@ -491,6 +492,58 @@ of the output:
     
     
 
+
+Note that the default type of the ``ndarray`` is ``float``. Hence, if
+the array is initialised from another array, type conversion will always
+take place, except, when the output type is specifically supplied. I.e.,
+
+.. code::
+        
+    # code to be run in micropython
+    
+    import ulab as np
+    
+    a = np.array(range(5), dtype=np.uint8)
+    b = np.array(a)
+    print("a:\t", a)
+    print("\nb:\t", b)
+
+.. parsed-literal::
+
+    a:	 array([0, 1, 2, 3, 4], dtype=uint8)
+    
+    b:	 array([0.0, 1.0, 2.0, 3.0, 4.0], dtype=float)
+    
+    
+
+
+will iterate over the elements in ``a``, since in the assignment
+``b = np.array(a)`` no output type was given, therefore, ``float`` was
+assumed. On the other hand,
+
+.. code::
+        
+    # code to be run in micropython
+    
+    import ulab as np
+    
+    a = np.array(range(5), dtype=np.uint8)
+    b = np.array(a, dtype=np.uint8)
+    print("a:\t", a)
+    print("\nb:\t", b)
+
+.. parsed-literal::
+
+    a:	 array([0, 1, 2, 3, 4], dtype=uint8)
+    
+    b:	 array([0, 1, 2, 3, 4], dtype=uint8)
+    
+    
+
+
+will simply copy the content of ``a`` into ``b`` without any iteration,
+and will, therefore, be faster. Keep this in mind, whenever the output
+type, or performance is important.
 
 Array initialisation functions
 ------------------------------

--- a/docs/ulab-change-log.md
+++ b/docs/ulab-change-log.md
@@ -1,3 +1,9 @@
+Thu, 2 Apr 2020
+
+version 0.38.1
+
+	added fast option, when initialising from ndarray_properties
+	
 Thu, 12 Mar 2020
 
 version 0.38.0

--- a/docs/ulab-manual.ipynb
+++ b/docs/ulab-manual.ipynb
@@ -2,11 +2,11 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 1,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2020-03-16T18:32:17.091606Z",
-     "start_time": "2020-03-16T18:32:17.083456Z"
+     "end_time": "2020-04-02T07:43:29.980724Z",
+     "start_time": "2020-04-02T07:43:28.557519Z"
     }
    },
    "outputs": [
@@ -24,11 +24,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 8,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2020-03-12T16:06:33.816806Z",
-     "start_time": "2020-03-12T16:06:33.749423Z"
+     "end_time": "2020-04-02T07:49:38.470172Z",
+     "start_time": "2020-04-02T07:49:38.464804Z"
     }
    },
    "outputs": [
@@ -66,7 +66,7 @@
     "author = 'Zoltán Vörös'\n",
     "\n",
     "# The full version, including alpha/beta/rc tags\n",
-    "release = '0.38.0'\n",
+    "release = '0.38.1'\n",
     "\n",
     "\n",
     "# -- General configuration ---------------------------------------------------\n",
@@ -120,11 +120,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 9,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2020-03-12T16:24:51.863344Z",
-     "start_time": "2020-03-12T16:24:46.494944Z"
+     "end_time": "2020-04-02T07:49:52.803364Z",
+     "start_time": "2020-04-02T07:49:44.457778Z"
     }
    },
    "outputs": [],
@@ -300,11 +300,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 4,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2020-03-16T18:32:33.498721Z",
-     "start_time": "2020-03-16T18:32:33.495049Z"
+     "end_time": "2020-04-02T07:46:51.107558Z",
+     "start_time": "2020-04-02T07:46:51.102879Z"
     }
    },
    "outputs": [],
@@ -318,11 +318,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 5,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2020-03-16T18:32:34.792651Z",
-     "start_time": "2020-03-16T18:32:34.694245Z"
+     "end_time": "2020-04-02T07:46:52.592354Z",
+     "start_time": "2020-04-02T07:46:52.554346Z"
     }
    },
    "outputs": [],
@@ -856,7 +856,7 @@
    "source": [
     "### Initialising by passing arrays\n",
     "\n",
-    "An `ndarray` can be initialised by supplying another array. This statement is almost trivial, since `ndarray`s are iterables themselves, though it should be pointed out that initialising through arrays is faster, because simply a new copy is created, without inspection, iteration etc. It is also possible to coerce type conversion of the output:"
+    "An `ndarray` can be initialised by supplying another array. This statement is almost trivial, since `ndarray`s are iterables themselves, though it should be pointed out that initialising through arrays is faster, because simply a new copy is created, without inspection, iteration etc. It is also possible to coerce type conversion of the output (with type conversion, the iteration cannot be avoided, therefore, this case will always be slower than straight copying):"
    ]
   },
   {
@@ -899,6 +899,93 @@
     "print(\"\\nb:\\t\", b)\n",
     "print(\"\\nc:\\t\", c)\n",
     "print(\"\\nd:\\t\", d)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that the default type of the `ndarray` is `float`. Hence, if the array is initialised from another array, type conversion will always take place, except, when the output type is specifically supplied. I.e., "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-04-02T07:47:01.402544Z",
+     "start_time": "2020-04-02T07:47:01.384496Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "a:\t array([0, 1, 2, 3, 4], dtype=uint8)\n",
+      "\n",
+      "b:\t array([0.0, 1.0, 2.0, 3.0, 4.0], dtype=float)\n",
+      "\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%micropython -unix 1\n",
+    "\n",
+    "import ulab as np\n",
+    "\n",
+    "a = np.array(range(5), dtype=np.uint8)\n",
+    "b = np.array(a)\n",
+    "print(\"a:\\t\", a)\n",
+    "print(\"\\nb:\\t\", b)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "will iterate over the elements in `a`, since in the assignment `b = np.array(a)` no output type was given, therefore, `float` was assumed. On the other hand, "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-04-02T07:48:13.707533Z",
+     "start_time": "2020-04-02T07:48:13.697810Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "a:\t array([0, 1, 2, 3, 4], dtype=uint8)\n",
+      "\n",
+      "b:\t array([0, 1, 2, 3, 4], dtype=uint8)\n",
+      "\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%micropython -unix 1\n",
+    "\n",
+    "import ulab as np\n",
+    "\n",
+    "a = np.array(range(5), dtype=np.uint8)\n",
+    "b = np.array(a, dtype=np.uint8)\n",
+    "print(\"a:\\t\", a)\n",
+    "print(\"\\nb:\\t\", b)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "will simply copy the content of `a` into `b` without any iteration, and will, therefore, be faster. Keep this in mind, whenever the output type, or performance is important."
    ]
   },
   {


### PR DESCRIPTION
This modification adds the fast initialisation option the `ndarray_make_new_core`, namely, if an ndarray is initialised from another ndarray, and the dtypes are identical, then the contents will simply be copied without inspection, iteration, etc. This should be significantly faster than the old method.