### PR TITLE
Restore circuitpython compatibility after #84

### DIFF
--- a/code/ulab.c
+++ b/code/ulab.c
@@ -50,7 +50,9 @@ STATIC MP_DEFINE_CONST_DICT(ulab_ndarray_locals_dict, ulab_ndarray_locals_dict_t
 
 const mp_obj_type_t ulab_ndarray_type = {
     { &mp_type_type },
+#if defined(MP_TYPE_FLAG_EQ_CHECKS_OTHER_TYPE) && defined(MP_TYPE_FLAG_EQ_HAS_NEQ_TEST)
     .flags = MP_TYPE_FLAG_EQ_CHECKS_OTHER_TYPE | MP_TYPE_FLAG_EQ_HAS_NEQ_TEST,
+#endif
     .name = MP_QSTR_ndarray,
     .print = ndarray_print,
     .make_new = ndarray_make_new,


### PR DESCRIPTION
#84 makes use of a recently added micropython feature.  Use preprocessor tests to restore compatibility when building in CircuitPython.