### PR TITLE
polyfit: Argument handling improvements

### DIFF
--- a/code/poly.c
+++ b/code/poly.c
@@ -102,9 +102,12 @@ static mp_obj_t poly_polyfit(size_t  n_args, const mp_obj_t *args) {
         }
         y = m_new(mp_float_t, leny);
         fill_array_iterable(y, args[0]);
-    } else if(n_args == 3) {
+    } else /* n_args == 3 */ {
+        if(!object_is_nditerable(args[1])) {
+            mp_raise_ValueError(translate("input data must be an iterable"));
+        }
         lenx = (uint16_t)mp_obj_get_int(mp_obj_len_maybe(args[0]));
-        leny = (uint16_t)mp_obj_get_int(mp_obj_len_maybe(args[0]));
+        leny = (uint16_t)mp_obj_get_int(mp_obj_len_maybe(args[1]));
         if(lenx != leny) {
             mp_raise_ValueError(translate("input vectors must be of equal length"));
         }


### PR DESCRIPTION
 * In the 3-args case, the lengths of the arguments were not checked
 * in the 3-args case, the type of the 2nd argument was not checked
 * gcc falsely diagnosed a `maybe-uninitialized` variable because it did not see that the branches of the if() statement were mutually exclusive

It's this third issue that originally drew my attention to this code, adafruit/circuitpython#2787