### PR TITLE
Added support for BLAS saxpy and sdot

### DIFF
--- a/code/blas.h
+++ b/code/blas.h
@@ -1,0 +1,163 @@
+#pragma once
+#include "f2c.h"
+
+
+#if(MICROPY_FLOAT_IMPL == MICROPY_FLOAT_IMPL_DOUBLE)
+#define ZERO 0.0
+#else
+#define ZERO 0.0f
+#endif
+
+/* Subroutine */ int axpy_(const integer *n, const mp_float_t *da, const mp_float_t *dx, 
+	const integer *incx, mp_float_t *dy, const integer *incy)
+{
+    /* System generated locals */
+    integer i__1;
+
+    /* Local variables */
+    static integer i__, m, ix, iy, mp1;
+
+    --dy;
+    --dx;
+
+    /* Function Body */
+    if (*n <= 0) {
+	return 0;
+    }
+    if (*da == ZERO) {
+	return 0;
+    }
+    if (*incx == 1 && *incy == 1) {
+	m = *n % 4;
+	if (m != 0) {
+	    i__1 = m;
+	    for (i__ = 1; i__ <= i__1; ++i__) {
+		dy[i__] += *da * dx[i__];
+	    }
+	}
+	if (*n < 4) {
+	    return 0;
+	}
+	mp1 = m + 1;
+	i__1 = *n;
+	for (i__ = mp1; i__ <= i__1; i__ += 4) {
+	    dy[i__] += *da * dx[i__];
+	    dy[i__ + 1] += *da * dx[i__ + 1];
+	    dy[i__ + 2] += *da * dx[i__ + 2];
+	    dy[i__ + 3] += *da * dx[i__ + 3];
+	}
+    } else {
+
+/*        code for unequal increments or equal increments */
+/*          not equal to 1 */
+
+	ix = 1;
+	iy = 1;
+	if (*incx < 0) {
+	    ix = (-(*n) + 1) * *incx + 1;
+	}
+	if (*incy < 0) {
+	    iy = (-(*n) + 1) * *incy + 1;
+	}
+	i__1 = *n;
+	for (i__ = 1; i__ <= i__1; ++i__) {
+	    dy[iy] += *da * dx[ix];
+	    ix += *incx;
+	    iy += *incy;
+	}
+    }
+    return 0;
+} /* axpy_ */
+
+void cblas_axpy( const int N, const mp_float_t alpha, const mp_float_t *X,
+                       const int incX, mp_float_t *Y, const int incY)
+{
+   long int F77_N=N, F77_incX=incX, F77_incY=incY;
+   axpy_( &F77_N, &alpha, X, &F77_incX, Y, &F77_incY);
+}
+
+///SDOT
+mp_float_t sdot_(const integer *n, const mp_float_t *sx, const integer *incx, const mp_float_t *sy, const integer *incy)
+{
+    /* System generated locals */
+    integer i__1;
+    mp_float_t ret_val;
+
+    /* Local variables */
+    static integer i__, m, ix, iy, mp1;
+    static mp_float_t stemp;
+
+    /* Parameter adjustments */
+    --sy;
+    --sx;
+
+    /* Function Body */
+    stemp = ZERO;
+    ret_val = ZERO;
+    if (*n <= 0) {
+	return ret_val;
+    }
+    if (*incx == 1 && *incy == 1) {
+
+	m = *n % 5;
+	if (m != 0) {
+	    i__1 = m;
+	    for (i__ = 1; i__ <= i__1; ++i__) {
+		stemp += sx[i__] * sy[i__];
+	    }
+	    if (*n < 5) {
+		ret_val = stemp;
+		return ret_val;
+	    }
+	}
+	mp1 = m + 1;
+	i__1 = *n;
+	for (i__ = mp1; i__ <= i__1; i__ += 5) {
+	    stemp = stemp + sx[i__] * sy[i__] + sx[i__ + 1] * sy[i__ + 1] + 
+		    sx[i__ + 2] * sy[i__ + 2] + sx[i__ + 3] * sy[i__ + 3] + 
+		    sx[i__ + 4] * sy[i__ + 4];
+	}
+    } else {
+
+	ix = 1;
+	iy = 1;
+	if (*incx < 0) {
+	    ix = (-(*n) + 1) * *incx + 1;
+	}
+	if (*incy < 0) {
+	    iy = (-(*n) + 1) * *incy + 1;
+	}
+	i__1 = *n;
+	for (i__ = 1; i__ <= i__1; ++i__) {
+	    stemp += sx[ix] * sy[iy];
+	    ix += *incx;
+	    iy += *incy;
+	}
+    }
+    ret_val = stemp;
+    return ret_val;
+} /* sdot_ */
+
+
+/* Subroutine */ int sdotsub_(const integer *n, const mp_float_t *x, const integer *incx, const mp_float_t *y, 
+	const integer *incy, mp_float_t *dot)
+{
+    /* Parameter adjustments */
+    --y;
+    --x;
+
+    /* Function Body */
+    *dot = sdot_(n, &x[1], incx, &y[1], incy);
+    return 0;
+} /* sdotsub_ */
+
+
+mp_float_t cblas_dot( const int N, const mp_float_t *X,
+                      const int incX, const mp_float_t *Y, const int incY)
+{
+   mp_float_t dot;
+   long int F77_N=N, F77_incX=incX, F77_incY=incY;
+   sdotsub_( &F77_N, X, &F77_incX, Y, &F77_incY, &dot);
+   return dot;
+}
+

--- a/code/extras.c
+++ b/code/extras.c
@@ -19,6 +19,9 @@
 
 #if ULAB_EXTRAS_MODULE
 
+#include "blas.h"
+
+
 static mp_obj_t extras_spectrogram(size_t n_args, const mp_obj_t *args) {
     if(n_args == 2) {
         return fft_fft_ifft_spectrum(n_args, args[0], args[1], FFT_SPECTRUM);
@@ -27,11 +30,134 @@ static mp_obj_t extras_spectrogram(size_t n_args, const mp_obj_t *args) {
     }
 }
 
+static mp_obj_t extras_blas_saxpy(size_t n_args, const mp_obj_t *args) {
+    int        N     = 0;
+    mp_float_t alpha = (mp_float_t)0;
+    int        incX  = 1;
+    int        incY  = 1;
+   
+    int x_loc = 2;
+    int y_loc = 4;
+
+    if(n_args == 6) {
+        N     = mp_obj_get_int(args[0]);
+        alpha = mp_obj_get_float(args[1]);
+        incX  = mp_obj_get_int(args[3]);
+        incY  = mp_obj_get_int(args[5]);
+    }
+    else if(n_args == 5){
+        alpha = mp_obj_get_float(args[0]);
+        incX  = mp_obj_get_int(args[2]);
+        incY  = mp_obj_get_int(args[4]);
+        x_loc = 1;
+        y_loc = 3;
+        ndarray_obj_t *Xptr = MP_OBJ_TO_PTR(args[x_loc]);
+        N = Xptr->array->len;
+
+    }
+    else if(n_args == 3){
+        x_loc = 1;
+        y_loc = 2;
+        alpha = mp_obj_get_float(args[0]);
+        ndarray_obj_t *Xptr = MP_OBJ_TO_PTR(args[x_loc]);
+        N = Xptr->array->len;
+    }
+    else{
+        mp_raise_ValueError(translate("usage saxpy(N,alpha,x,inc,y,incy)||saxpy(N,alpha,x,incx,y,incy)||saxpy(N,alpha,x,y)"));
+    }
+
+    if(!MP_OBJ_IS_TYPE(args[x_loc], &ulab_ndarray_type) || !MP_OBJ_IS_TYPE(args[y_loc], &ulab_ndarray_type)) {
+        mp_raise_NotImplementedError(translate("SAXPY is defined for ndarrays only"));
+    } 
+
+    int len;
+    ndarray_obj_t *Xptr = MP_OBJ_TO_PTR(args[x_loc]);
+    len = Xptr->array->len;
+    if((len) != (N*incX)) {
+        mp_raise_ValueError(translate("size mismatch X"));
+    }
+
+    ndarray_obj_t *Yptr = MP_OBJ_TO_PTR(args[y_loc]);
+    len = Yptr->array->len;
+    if((len) != (N*incY)) {
+        mp_raise_ValueError(translate("size mismatch Y"));
+    }    
+    if((Xptr->array->typecode != NDARRAY_FLOAT) || (Yptr->array->typecode != NDARRAY_FLOAT)) { 
+        mp_raise_ValueError(translate("only for float"));
+    }
+    mp_float_t *X = (mp_float_t *)Xptr->array->items;
+    mp_float_t *Y = (mp_float_t *)Yptr->array->items;
+    cblas_axpy(N,alpha,X,incX,Y,incY);
+
+    return args[y_loc];
+}
+
+static mp_obj_t extras_blas_sdot(size_t n_args, const mp_obj_t *args) {
+    int        N     = 0;
+    int        incX  = 1;
+    int        incY  = 1;
+   
+    int x_loc = 1;
+    int y_loc = 3;
+
+    if(n_args == 5) {
+        N     = mp_obj_get_int(args[0]);
+        incX  = mp_obj_get_int(args[2]);
+        incY  = mp_obj_get_int(args[4]);
+    }
+    else if(n_args == 4) {
+        incX  = mp_obj_get_int(args[1]);
+        incY  = mp_obj_get_int(args[3]);
+        x_loc = 0;
+        y_loc = 2;
+        ndarray_obj_t *Xptr = MP_OBJ_TO_PTR(args[x_loc]);
+        N = Xptr->array->len;
+    }
+    else if(n_args == 2){
+        x_loc = 0;
+        y_loc = 1;
+        ndarray_obj_t *Xptr = MP_OBJ_TO_PTR(args[x_loc]);
+        N = Xptr->array->len;
+
+    }
+    else{
+        mp_raise_ValueError(translate("usage sdot(N,x,inc,y,incy)||sdot(x,incx,y,incy)||sdot(x,y)"));
+    }
+
+    if(!MP_OBJ_IS_TYPE(args[x_loc], &ulab_ndarray_type) || !MP_OBJ_IS_TYPE(args[y_loc], &ulab_ndarray_type)) {
+        mp_raise_NotImplementedError(translate("SAXPY is defined for ndarrays only"));
+    } 
+
+
+    int len;
+    ndarray_obj_t *Xptr = MP_OBJ_TO_PTR(args[x_loc]);
+    len = Xptr->array->len;
+    if((len) != (N*incX)) {
+        mp_raise_ValueError(translate("size mismatch X"));
+    }
+
+    ndarray_obj_t *Yptr = MP_OBJ_TO_PTR(args[y_loc]);
+    len = Yptr->array->len;
+    if((len) != (N*incY)) {
+        mp_raise_ValueError(translate("size mismatch Y"));
+    }    
+    if((Xptr->array->typecode != NDARRAY_FLOAT) || (Yptr->array->typecode != NDARRAY_FLOAT)) { 
+        mp_raise_ValueError(translate("only for float"));
+    }
+    mp_float_t *X = (mp_float_t *)Xptr->array->items;
+    mp_float_t *Y = (mp_float_t *)Yptr->array->items;
+    return mp_obj_new_float(cblas_dot(N,X,incX,Y,incY));
+}
+
 MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(extras_spectrogram_obj, 1, 2, extras_spectrogram);
+MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(extras_blas_saxpy_obj, 3, 6, extras_blas_saxpy);
+MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(extras_blas_sdot_obj, 2, 5, extras_blas_sdot);
 
 STATIC const mp_rom_map_elem_t ulab_extras_globals_table[] = {
     { MP_OBJ_NEW_QSTR(MP_QSTR___name__), MP_OBJ_NEW_QSTR(MP_QSTR_extras) },
 	{ MP_OBJ_NEW_QSTR(MP_QSTR_spectrogram), (mp_obj_t)&extras_spectrogram_obj },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_blas_saxpy), (mp_obj_t)&extras_blas_saxpy_obj },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_blas_sdot), (mp_obj_t)&extras_blas_sdot_obj },
 };
 
 STATIC MP_DEFINE_CONST_DICT(mp_module_ulab_extras_globals, ulab_extras_globals_table);

--- a/code/f2c.h
+++ b/code/f2c.h
@@ -1,0 +1,223 @@
+/* f2c.h  --  Standard Fortran to C header file */
+
+/**  barf  [ba:rf]  2.  "He suggested using FORTRAN, and everybody barfed."
+
+	- From The Shogakukan DICTIONARY OF NEW ENGLISH (Second edition) */
+
+#ifndef F2C_INCLUDE
+#define F2C_INCLUDE
+
+typedef long int integer;
+typedef unsigned long int uinteger;
+typedef char *address;
+typedef short int shortint;
+typedef float real;
+typedef double doublereal;
+typedef struct { real r, i; } complex;
+typedef struct { doublereal r, i; } doublecomplex;
+typedef long int logical;
+typedef short int shortlogical;
+typedef char logical1;
+typedef char integer1;
+#ifdef INTEGER_STAR_8	/* Adjust for integer*8. */
+typedef long long longint;		/* system-dependent */
+typedef unsigned long long ulongint;	/* system-dependent */
+#define qbit_clear(a,b)	((a) & ~((ulongint)1 << (b)))
+#define qbit_set(a,b)	((a) |  ((ulongint)1 << (b)))
+#endif
+
+#define TRUE_ (1)
+#define FALSE_ (0)
+
+/* Extern is for use with -E */
+#ifndef Extern
+#define Extern extern
+#endif
+
+/* I/O stuff */
+
+#ifdef f2c_i2
+/* for -i2 */
+typedef short flag;
+typedef short ftnlen;
+typedef short ftnint;
+#else
+typedef long int flag;
+typedef long int ftnlen;
+typedef long int ftnint;
+#endif
+
+/*external read, write*/
+typedef struct
+{	flag cierr;
+	ftnint ciunit;
+	flag ciend;
+	char *cifmt;
+	ftnint cirec;
+} cilist;
+
+/*internal read, write*/
+typedef struct
+{	flag icierr;
+	char *iciunit;
+	flag iciend;
+	char *icifmt;
+	ftnint icirlen;
+	ftnint icirnum;
+} icilist;
+
+/*open*/
+typedef struct
+{	flag oerr;
+	ftnint ounit;
+	char *ofnm;
+	ftnlen ofnmlen;
+	char *osta;
+	char *oacc;
+	char *ofm;
+	ftnint orl;
+	char *oblnk;
+} olist;
+
+/*close*/
+typedef struct
+{	flag cerr;
+	ftnint cunit;
+	char *csta;
+} cllist;
+
+/*rewind, backspace, endfile*/
+typedef struct
+{	flag aerr;
+	ftnint aunit;
+} alist;
+
+/* inquire */
+typedef struct
+{	flag inerr;
+	ftnint inunit;
+	char *infile;
+	ftnlen infilen;
+	ftnint	*inex;	/*parameters in standard's order*/
+	ftnint	*inopen;
+	ftnint	*innum;
+	ftnint	*innamed;
+	char	*inname;
+	ftnlen	innamlen;
+	char	*inacc;
+	ftnlen	inacclen;
+	char	*inseq;
+	ftnlen	inseqlen;
+	char 	*indir;
+	ftnlen	indirlen;
+	char	*infmt;
+	ftnlen	infmtlen;
+	char	*inform;
+	ftnint	informlen;
+	char	*inunf;
+	ftnlen	inunflen;
+	ftnint	*inrecl;
+	ftnint	*innrec;
+	char	*inblank;
+	ftnlen	inblanklen;
+} inlist;
+
+#define VOID void
+
+union Multitype {	/* for multiple entry points */
+	integer1 g;
+	shortint h;
+	integer i;
+	/* longint j; */
+	real r;
+	doublereal d;
+	complex c;
+	doublecomplex z;
+	};
+
+typedef union Multitype Multitype;
+
+/*typedef long int Long;*/	/* No longer used; formerly in Namelist */
+
+struct Vardesc {	/* for Namelist */
+	char *name;
+	char *addr;
+	ftnlen *dims;
+	int  type;
+	};
+typedef struct Vardesc Vardesc;
+
+struct Namelist {
+	char *name;
+	Vardesc **vars;
+	int nvars;
+	};
+typedef struct Namelist Namelist;
+
+//#define abs(x) ((x) >= 0 ? (x) : -(x))
+#define dabs(x) (doublereal)abs(x)
+#define min(a,b) ((a) <= (b) ? (a) : (b))
+#define max(a,b) ((a) >= (b) ? (a) : (b))
+#define dmin(a,b) (doublereal)min(a,b)
+#define dmax(a,b) (doublereal)max(a,b)
+#define bit_test(a,b)	((a) >> (b) & 1)
+#define bit_clear(a,b)	((a) & ~((uinteger)1 << (b)))
+#define bit_set(a,b)	((a) |  ((uinteger)1 << (b)))
+
+/* procedure parameter types for -A and -C++ */
+
+#define F2C_proc_par_types 1
+#ifdef __cplusplus
+typedef int /* Unknown procedure type */ (*U_fp)(...);
+typedef shortint (*J_fp)(...);
+typedef integer (*I_fp)(...);
+typedef real (*R_fp)(...);
+typedef doublereal (*D_fp)(...), (*E_fp)(...);
+typedef /* Complex */ VOID (*C_fp)(...);
+typedef /* Double Complex */ VOID (*Z_fp)(...);
+typedef logical (*L_fp)(...);
+typedef shortlogical (*K_fp)(...);
+typedef /* Character */ VOID (*H_fp)(...);
+typedef /* Subroutine */ int (*S_fp)(...);
+#else
+typedef int /* Unknown procedure type */ (*U_fp)();
+typedef shortint (*J_fp)();
+typedef integer (*I_fp)();
+typedef real (*R_fp)();
+typedef doublereal (*D_fp)(), (*E_fp)();
+typedef /* Complex */ VOID (*C_fp)();
+typedef /* Double Complex */ VOID (*Z_fp)();
+typedef logical (*L_fp)();
+typedef shortlogical (*K_fp)();
+typedef /* Character */ VOID (*H_fp)();
+typedef /* Subroutine */ int (*S_fp)();
+#endif
+/* E_fp is for real functions when -R is not specified */
+typedef VOID C_f;	/* complex function */
+typedef VOID H_f;	/* character function */
+typedef VOID Z_f;	/* double complex function */
+typedef doublereal E_f;	/* real function with -R not specified */
+
+/* undef any lower-case symbols that your C compiler predefines, e.g.: */
+
+#ifndef Skip_f2c_Undefs
+#undef cray
+#undef gcos
+#undef mc68010
+#undef mc68020
+#undef mips
+#undef pdp11
+#undef sgi
+#undef sparc
+#undef sun
+#undef sun2
+#undef sun3
+#undef sun4
+#undef u370
+#undef u3b
+#undef u3b2
+#undef u3b5
+#undef unix
+#undef vax
+#endif
+#endif


### PR DESCRIPTION
I converted some BLAS functions with f2c, saxpy and sdot, and added them to the extra module.
If MICROPY_FLOAT_IMPL is MICROPY_FLOAT_IMPL_DOUBLE it computes daxpy and ddot.

I tried it out on the micropython unix port.
It would be interesting to also have sgemv, sgemm, strsm, and their complex counterpart.

Please let me know if you need code refactoring.