### PR TITLE
added first implementation of interp to poly

### DIFF
--- a/code/poly.c
+++ b/code/poly.c
@@ -197,7 +197,7 @@ mp_obj_t poly_interp(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args)
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_, MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_rom_obj = mp_const_none } },
         { MP_QSTR_, MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_rom_obj = mp_const_none } },
-		{ MP_QSTR_, MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_rom_obj = mp_const_none } },
+        { MP_QSTR_, MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_rom_obj = mp_const_none } },
         { MP_QSTR_left, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_rom_obj = mp_const_none} },
         { MP_QSTR_right, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_rom_obj = mp_const_none} },
     };

--- a/code/poly.c
+++ b/code/poly.c
@@ -193,10 +193,76 @@ static mp_obj_t poly_polyfit(size_t  n_args, const mp_obj_t *args) {
 
 MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(poly_polyfit_obj, 2, 3, poly_polyfit);
 
+mp_obj_t poly_interp(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+    static const mp_arg_t allowed_args[] = {
+        { MP_QSTR_, MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_rom_obj = mp_const_none } },
+        { MP_QSTR_, MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_rom_obj = mp_const_none } },
+		{ MP_QSTR_, MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_rom_obj = mp_const_none } },
+        { MP_QSTR_left, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_rom_obj = mp_const_none} },
+        { MP_QSTR_right, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_rom_obj = mp_const_none} },
+    };
+	mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
+    mp_arg_parse_all(n_args, pos_args, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
+	
+	ndarray_obj_t *x = ndarray_from_mp_obj(args[0].u_obj);
+	ndarray_obj_t *xp = ndarray_from_mp_obj(args[1].u_obj); // xp must hold an increasing sequence of independent values
+	ndarray_obj_t *fp = ndarray_from_mp_obj(args[2].u_obj);
+	// TODO: check if the shape is (1, n), or (m, 1)
+	if(((xp->m != 1) && (xp->n != 1)) || ((fp->m != 1) && (fp->n != 1)) || 
+		(xp->array->len < 2) || (fp->array->len < 2) || (xp->array->len != fp->array->len)) {
+		mp_raise_ValueError(translate("interp is defined for 1D arrays of equal length"));
+	}
+	ndarray_obj_t *y = create_new_ndarray(x->m, x->n, NDARRAY_FLOAT);
+	mp_float_t left_value, right_value;
+	mp_float_t xp_left = ndarray_get_float_value(xp->array->items, xp->array->typecode, 0);
+	mp_float_t xp_right = ndarray_get_float_value(xp->array->items, xp->array->typecode, xp->array->len-1);
+	if(args[3].u_obj == mp_const_none) {
+		left_value = ndarray_get_float_value(fp->array->items, fp->array->typecode, 0);
+	} else {
+		left_value = mp_obj_get_float(args[3].u_obj);
+	}
+	if(args[4].u_obj == mp_const_none) {
+		right_value = ndarray_get_float_value(fp->array->items, fp->array->typecode, fp->array->len-1);
+	} else {
+		right_value = mp_obj_get_float(args[4].u_obj);
+	}
+	mp_float_t *yarray = (mp_float_t *)y->array->items;
+	for(size_t i=0; i < x->array->len; i++, yarray++) {
+		mp_float_t x_value = ndarray_get_float_value(x->array->items, x->array->typecode, i);
+		if(x_value <= xp_left) {
+			*yarray = left_value;
+		} else if(x_value >= xp_right) {
+			*yarray = right_value;
+		} else { // do the binary search here
+			mp_float_t xp_left_, xp_right_;
+			mp_float_t fp_left, fp_right;
+			size_t left_index = 0, right_index = xp->array->len - 1, middle_index;
+			while(right_index - left_index > 1) {
+				middle_index = left_index + (right_index - left_index) / 2;
+				mp_float_t xp_middle = ndarray_get_float_value(xp->array->items, xp->array->typecode, middle_index);
+				if(x_value <= xp_middle) {
+					right_index = middle_index;
+				} else {
+					left_index = middle_index;
+				}
+			}
+			xp_left_ = ndarray_get_float_value(xp->array->items, xp->array->typecode, left_index);
+			xp_right_ = ndarray_get_float_value(xp->array->items, xp->array->typecode, right_index);
+			fp_left = ndarray_get_float_value(fp->array->items, fp->array->typecode, left_index);
+			fp_right = ndarray_get_float_value(fp->array->items, fp->array->typecode, right_index);
+			*yarray = fp_left + (x_value - xp_left_) * (fp_right - fp_left) / (xp_right_ - xp_left_);
+		}
+	}
+	return MP_OBJ_FROM_PTR(y);
+}
+
+MP_DEFINE_CONST_FUN_OBJ_KW(poly_interp_obj, 2, poly_interp);
+
 STATIC const mp_rom_map_elem_t ulab_poly_globals_table[] = {
     { MP_OBJ_NEW_QSTR(MP_QSTR___name__), MP_OBJ_NEW_QSTR(MP_QSTR_poly) },
     { MP_OBJ_NEW_QSTR(MP_QSTR_polyval), (mp_obj_t)&poly_polyval_obj },
     { MP_OBJ_NEW_QSTR(MP_QSTR_polyfit), (mp_obj_t)&poly_polyfit_obj },
+    { MP_OBJ_NEW_QSTR(MP_QSTR_interp), (mp_obj_t)&poly_interp_obj },    
 };
 
 STATIC MP_DEFINE_CONST_DICT(mp_module_ulab_poly_globals, ulab_poly_globals_table);

--- a/code/poly.h
+++ b/code/poly.h
@@ -20,6 +20,7 @@ extern mp_obj_module_t ulab_poly_module;
 
 MP_DECLARE_CONST_FUN_OBJ_2(poly_polyval_obj);
 MP_DECLARE_CONST_FUN_OBJ_VAR_BETWEEN(poly_polyfit_obj);
+MP_DECLARE_CONST_FUN_OBJ_KW(poly_interp_obj);
 
 #endif
 #endif

--- a/code/ulab.c
+++ b/code/ulab.c
@@ -31,7 +31,7 @@
 #include "compare.h"
 #include "extras.h"
 
-STATIC MP_DEFINE_STR_OBJ(ulab_version_obj, "0.42.0");
+STATIC MP_DEFINE_STR_OBJ(ulab_version_obj, "0.43.0");
 
 MP_DEFINE_CONST_FUN_OBJ_KW(ndarray_flatten_obj, 1, ndarray_flatten);
 

--- a/docs/ulab-change-log.md
+++ b/docs/ulab-change-log.md
@@ -1,3 +1,7 @@
+Sun, 26 Apr 2020
+
+	add interp to poly
+
 Tue, 21 Apr 2020
 
 version 0.42.0

--- a/tests/interp.py
+++ b/tests/interp.py
@@ -1,0 +1,18 @@
+import ulab
+from ulab import poly
+
+x = ulab.array([1, 2, 3, 4, 5])
+xp = ulab.array([1, 2, 3, 4])
+fp = ulab.array([1, 2, 3, 4])
+x = x - 0.5
+print(poly.interp(x, xp, fp))
+print(poly.interp(x, xp, fp, left=0.0))
+print(poly.interp(x, xp, fp, right=10.0))
+
+x = ulab.array([1, 2, 3, 4, 5])
+xp = ulab.array([1, 2, 3, 4])
+fp = ulab.array([1, 2, 3, 5])
+x = x - 0.2
+print(poly.interp(x, xp, fp))
+print(poly.interp(x, xp, fp, left=0.0))
+print(poly.interp(x, xp, fp, right=10.0))

--- a/tests/interp.py.exp
+++ b/tests/interp.py.exp
@@ -1,0 +1,6 @@
+array([1.0, 1.5, 2.5, 3.5, 4.0], dtype=float)
+array([0.0, 1.5, 2.5, 3.5, 4.0], dtype=float)
+array([1.0, 1.5, 2.5, 3.5, 10.0], dtype=float)
+array([1.0, 1.8, 2.8, 4.6, 5.0], dtype=float)
+array([0.0, 1.8, 2.8, 4.6, 5.0], dtype=float)
+array([1.0, 1.8, 2.8, 4.6, 10.0], dtype=float)


### PR DESCRIPTION
@jepler Jeff, could you, please, look at the code? It responds to https://github.com/v923z/micropython-ulab/issues/107, which, in turn, came from the `circuitpython` repository, https://github.com/adafruit/CircuitPython_Community_Bundle/pull/37. 
I have also added a test script. The documentation is not yet written, partly because that depends on the outcome of the discussion below.

@95Fox could you, please, check out the `interp` branch, and see if it works properly? It would also be really cool, if you could contribute to the test script: https://github.com/v923z/micropython-ulab/blob/interp/tests/interp.py You will also find usage examples there. Thanks!

@tannewt This implementation adds the `interp` function of `numpy` to the `poly` sub-module. I am not sure that that is sensible. I am open to suggestions as to where it could go to. The function itself uses a bit more than 1 kB of flash space. The logical place would be `numerical`, but that is already too heavy with 12 kB, and by adding more stuff to that, we would lose the advantages of sub-modules.

As a bit of forecast, I would definitely like to add root finding (it is oddly in `scipy.optimize`: https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.newton.html) in the foreseeable future (1-2 weeks), so in principle, we could assign a new sub-module to `newton`, and `interp`. But I would still need a name, please!