### PR TITLE
ulab.h: Actually allow excluding modules

### DIFF
--- a/code/ulab.h
+++ b/code/ulab.h
@@ -16,27 +16,43 @@
 #define ULAB_CREATE_MODULE (1)
 
 // vectorise (all functions) takes approx. 4.5 kB of flash space
+#ifndef ULAB_VECTORISE_MODULE
 #define ULAB_VECTORISE_MODULE (1)
+#endif
 
 // linalg adds around 6 kB to the firmware
+#ifndef ULAB_LINALG_MODULE
 #define ULAB_LINALG_MODULE (1)
+#endif
 
 // poly requires approx. 2.5 kB
+#ifndef ULAB_POLY_MODULE
 #define ULAB_POLY_MODULE (1)
+#endif
 
 // numerical is about 12 kB
+#ifndef ULAB_NUMERICAL_MODULE
 #define ULAB_NUMERICAL_MODULE (1)
+#endif
 
 // FFT costs about 2 kB of flash space
+#ifndef ULAB_FFT_MODULE
 #define ULAB_FFT_MODULE (1)
+#endif
 
 // the filter module occupies about 1 kB of flash space
+#ifndef ULAB_FILTER_MODULE
 #define ULAB_FILTER_MODULE (1)
+#endif
 
 // the compare module consumes about 4 kB of flash space
+#ifndef ULAB_COMPARE_MODULE
 #define ULAB_COMPARE_MODULE (1)
+#endif
 
 // user-defined modules
+#ifndef ULAB_EXTRAS_MODULE
 #define ULAB_EXTRAS_MODULE (1)
+#endif
 
 #endif


### PR DESCRIPTION
Perhaps I'm overlooking something, but when I tried to _actually_ disable a module by adding
`#define ULAB_COMPARE_MODULE (0)` in an mpconfigboard.h, I got multiple diagnostics like
```
../../extmod/ulab/code/ulab.h:37: error: "ULAB_COMPARE_MODULE" redefined [-Werror]
```

Therefore, in ulab.h, check whether the enabling-symbol is defined or not before defining it to (1) to enable everything by default.

This is not done for ULAB_CREATE_MODULE since, as the comments note, it is always enabled.

We may need to use this in CircuitPython soon because, at the moment, adding ulab.compare overflows one build, the espruino pico (stm).  See adafruit/circuitpython#2811 for progress integrating the current (or now slightly old :frowning:) ulab.