### PR TITLE
added set_printoptions/get_printoptions functions

### DIFF
--- a/code/ndarray.c
+++ b/code/ndarray.c
@@ -20,6 +20,9 @@
 #include "py/objtuple.h"
 #include "ndarray.h"
 
+mp_uint_t ndarray_print_threshold = NDARRAY_PRINT_THRESHOLD;
+mp_uint_t ndarray_print_edgeitems = NDARRAY_PRINT_EDGEITEMS;
+
 // This function is copied verbatim from objarray.c
 STATIC mp_obj_array_t *array_new(char typecode, size_t n) {
     int typecode_size = mp_binary_get_size('@', typecode, NULL);
@@ -63,25 +66,53 @@ void fill_array_iterable(mp_float_t *array, mp_obj_t iterable) {
     }
 }
 
+mp_obj_t ndarray_set_printoptions(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+	static const mp_arg_t allowed_args[] = {
+		{ MP_QSTR_threshold, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_rom_obj = mp_const_none} },
+		{ MP_QSTR_edgeitems, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_rom_obj = mp_const_none} },
+	};
+
+	mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
+	mp_arg_parse_all(n_args, pos_args, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
+	if(args[0].u_rom_obj != mp_const_none) {
+		ndarray_print_threshold = mp_obj_get_int(args[0].u_rom_obj);
+	}
+	if(args[1].u_rom_obj != mp_const_none) {
+		ndarray_print_edgeitems = mp_obj_get_int(args[1].u_rom_obj);
+	}
+	return mp_const_none;
+}
+
+MP_DEFINE_CONST_FUN_OBJ_KW(ndarray_set_printoptions_obj, 0, ndarray_set_printoptions);
+
+mp_obj_t ndarray_get_printoptions(void) {
+	mp_obj_t dict = mp_obj_new_dict(2);
+	mp_obj_dict_store(MP_OBJ_FROM_PTR(dict), MP_OBJ_NEW_QSTR(MP_QSTR_threshold), mp_obj_new_int(ndarray_print_threshold));
+	mp_obj_dict_store(MP_OBJ_FROM_PTR(dict), MP_OBJ_NEW_QSTR(MP_QSTR_edgeitems), mp_obj_new_int(ndarray_print_edgeitems));
+    return dict;
+}
+
+MP_DEFINE_CONST_FUN_OBJ_0(ndarray_get_printoptions_obj, ndarray_get_printoptions);
+
 void ndarray_print_row(const mp_print_t *print, mp_obj_array_t *data, size_t n0, size_t n) {
     mp_print_str(print, "[");
-    if(n < PRINT_MAX) { // if the array is short, print everything
+    if((n <= ndarray_print_threshold) || (n <= 2*ndarray_print_edgeitems)) { // if the array is short, print everything
         mp_obj_print_helper(print, mp_binary_get_val_array(data->typecode, data->items, n0), PRINT_REPR);
-        for(size_t i=1; i<n; i++) {
+        for(size_t i=1; i < n; i++) {
             mp_print_str(print, ", ");
             mp_obj_print_helper(print, mp_binary_get_val_array(data->typecode, data->items, n0+i), PRINT_REPR);
         }
     } else {
         mp_obj_print_helper(print, mp_binary_get_val_array(data->typecode, data->items, n0), PRINT_REPR);
-        for(size_t i=1; i<3; i++) {
+        for(size_t i=1; i < ndarray_print_edgeitems; i++) {
             mp_print_str(print, ", ");
             mp_obj_print_helper(print, mp_binary_get_val_array(data->typecode, data->items, n0+i), PRINT_REPR);
         }
         mp_printf(print, ", ..., ");
-        mp_obj_print_helper(print, mp_binary_get_val_array(data->typecode, data->items, n0+n-3), PRINT_REPR);
-        for(size_t i=1; i<3; i++) {
+        mp_obj_print_helper(print, mp_binary_get_val_array(data->typecode, data->items, n0+n-ndarray_print_edgeitems), PRINT_REPR);
+        for(size_t i=1; i < ndarray_print_edgeitems; i++) {
             mp_print_str(print, ", ");
-            mp_obj_print_helper(print, mp_binary_get_val_array(data->typecode, data->items, n0+n-3+i), PRINT_REPR);
+            mp_obj_print_helper(print, mp_binary_get_val_array(data->typecode, data->items, n0+n-ndarray_print_edgeitems+i), PRINT_REPR);
         }
     }
     mp_print_str(print, "]");
@@ -98,7 +129,7 @@ void ndarray_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t ki
         if((self->m == 1) || (self->n == 1)) {
             ndarray_print_row(print, self->array, 0, self->array->len);
         } else {
-            // TODO: add vertical ellipses for the case, when self->m > PRINT_MAX
+            // TODO: add vertical ellipses
             mp_print_str(print, "[");
             ndarray_print_row(print, self->array, 0, self->n);
             for(size_t i=1; i < self->m; i++) {

--- a/code/ndarray.h
+++ b/code/ndarray.h
@@ -17,7 +17,8 @@
 #include "py/objstr.h"
 #include "py/objlist.h"
 
-#define PRINT_MAX  10
+#define NDARRAY_PRINT_THRESHOLD  	10
+#define NDARRAY_PRINT_EDGEITEMS		3
 
 #if MICROPY_FLOAT_IMPL == MICROPY_FLOAT_IMPL_FLOAT
 #define FLOAT_TYPECODE 'f'
@@ -56,6 +57,10 @@ mp_obj_t mp_obj_new_ndarray_iterator(mp_obj_t , size_t , mp_obj_iter_buf_t *);
 mp_float_t ndarray_get_float_value(void *, uint8_t , size_t );
 void fill_array_iterable(mp_float_t *, mp_obj_t );
 
+mp_obj_t ndarray_set_printoptions(size_t , const mp_obj_t *, mp_map_t *);
+MP_DECLARE_CONST_FUN_OBJ_KW(ndarray_set_printoptions_obj);
+mp_obj_t ndarray_get_printoptions(void);
+MP_DECLARE_CONST_FUN_OBJ_0(ndarray_get_printoptions_obj);
 void ndarray_print_row(const mp_print_t *, mp_obj_array_t *, size_t , size_t );
 void ndarray_print(const mp_print_t *, mp_obj_t , mp_print_kind_t );
 void ndarray_assign_elements(mp_obj_array_t *, mp_obj_t , uint8_t , size_t *);

--- a/code/ulab.c
+++ b/code/ulab.c
@@ -68,6 +68,8 @@ const mp_obj_type_t ulab_ndarray_type = {
 STATIC const mp_map_elem_t ulab_globals_table[] = {
     { MP_OBJ_NEW_QSTR(MP_QSTR___name__), MP_OBJ_NEW_QSTR(MP_QSTR_ulab) },
     { MP_ROM_QSTR(MP_QSTR___version__), MP_ROM_PTR(&ulab_version_obj) },
+    { MP_ROM_QSTR(MP_QSTR_set_printoptions), (mp_obj_t)&ndarray_set_printoptions_obj },
+    { MP_ROM_QSTR(MP_QSTR_get_printoptions), (mp_obj_t)&ndarray_get_printoptions_obj },
     { MP_OBJ_NEW_QSTR(MP_QSTR_array), (mp_obj_t)&ulab_ndarray_type },
     { MP_ROM_QSTR(MP_QSTR_zeros), (mp_obj_t)&create_zeros_obj },
     { MP_ROM_QSTR(MP_QSTR_ones), (mp_obj_t)&create_ones_obj },

--- a/docs/manual/source/conf.py
+++ b/docs/manual/source/conf.py
@@ -22,7 +22,7 @@ copyright = '2019-2020, Zoltán Vörös'
 author = 'Zoltán Vörös'
 
 # The full version, including alpha/beta/rc tags
-release = '0.42.0'
+release = '0.43.0'
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/manual/source/ulab.rst
+++ b/docs/manual/source/ulab.rst
@@ -449,10 +449,13 @@ default.
     
 
 
-``ndarray``\ s are pretty-printed, i.e., if the length is larger than
-10, then only the first and last three entries will be printed. Also
-note that, as opposed to ``numpy``, the printout always contains the
-``dtype``.
+Customising array printouts
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``ndarray``\ s are pretty-printed, i.e., if the length is larger than 10
+(default value), then only the first and last three entries will be
+printed. Also note that, as opposed to ``numpy``, the printout always
+contains the ``dtype``.
 
 .. code::
         
@@ -466,6 +469,60 @@ note that, as opposed to ``numpy``, the printout always contains the
 .. parsed-literal::
 
     a:	 array([0.0, 1.0, 2.0, ..., 197.0, 198.0, 199.0], dtype=float)
+    
+    
+
+
+The default values can be overwritten by means of the
+``set_printoptions`` functions
+`numpy.set_printoptions <#https://numpy.org/doc/1.18/reference/generated/numpy.set_printoptions.html>`__,
+which accepts two keywords arguments, the ``threshold``, and the
+``edgeitems``. The first of these arguments determines the length of the
+longest array that will be printed in full, while the second is the
+number of items that will be printed on the left and right hand side of
+the ellipsis.
+
+.. code::
+        
+    # code to be run in micropython
+    
+    import ulab as np
+    
+    a = np.array(range(20))
+    print("a printed with defaults:\t", a)
+    
+    np.set_printoptions(threshold=200)
+    print("\na printed in full:\t\t", a)
+    
+    np.set_printoptions(threshold=10, edgeitems=2)
+    print("\na truncated with 2 edgeitems:\t", a)
+
+.. parsed-literal::
+
+    a printed with defaults:	 array([0.0, 1.0, 2.0, ..., 17.0, 18.0, 19.0], dtype=float)
+    
+    a printed in full:		 array([0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0], dtype=float)
+    
+    a truncated with 2 edgeitems:	 array([0.0, 1.0, ..., 18.0, 19.0], dtype=float)
+    
+    
+
+
+The set value of the ``threshold`` and ``edgeitems`` can be retrieved by
+calling the ``get_printoptions`` function with no arguments:
+
+.. code::
+        
+    # code to be run in micropython
+    
+    import ulab as np
+    
+    np.set_printoptions(threshold=100, edgeitems=20)
+    print(np.get_printoptions())
+
+.. parsed-literal::
+
+    {'threshold': 100, 'edgeitems': 20}
     
     
 

--- a/docs/manual/source/ulab.rst
+++ b/docs/manual/source/ulab.rst
@@ -449,84 +449,6 @@ default.
     
 
 
-Customising array printouts
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-``ndarray``\ s are pretty-printed, i.e., if the length is larger than 10
-(default value), then only the first and last three entries will be
-printed. Also note that, as opposed to ``numpy``, the printout always
-contains the ``dtype``.
-
-.. code::
-        
-    # code to be run in micropython
-    
-    import ulab as np
-    
-    a = np.array(range(200))
-    print("a:\t", a)
-
-.. parsed-literal::
-
-    a:	 array([0.0, 1.0, 2.0, ..., 197.0, 198.0, 199.0], dtype=float)
-    
-    
-
-
-The default values can be overwritten by means of the
-``set_printoptions`` functions
-`numpy.set_printoptions <#https://numpy.org/doc/1.18/reference/generated/numpy.set_printoptions.html>`__,
-which accepts two keywords arguments, the ``threshold``, and the
-``edgeitems``. The first of these arguments determines the length of the
-longest array that will be printed in full, while the second is the
-number of items that will be printed on the left and right hand side of
-the ellipsis.
-
-.. code::
-        
-    # code to be run in micropython
-    
-    import ulab as np
-    
-    a = np.array(range(20))
-    print("a printed with defaults:\t", a)
-    
-    np.set_printoptions(threshold=200)
-    print("\na printed in full:\t\t", a)
-    
-    np.set_printoptions(threshold=10, edgeitems=2)
-    print("\na truncated with 2 edgeitems:\t", a)
-
-.. parsed-literal::
-
-    a printed with defaults:	 array([0.0, 1.0, 2.0, ..., 17.0, 18.0, 19.0], dtype=float)
-    
-    a printed in full:		 array([0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0], dtype=float)
-    
-    a truncated with 2 edgeitems:	 array([0.0, 1.0, ..., 18.0, 19.0], dtype=float)
-    
-    
-
-
-The set value of the ``threshold`` and ``edgeitems`` can be retrieved by
-calling the ``get_printoptions`` function with no arguments:
-
-.. code::
-        
-    # code to be run in micropython
-    
-    import ulab as np
-    
-    np.set_printoptions(threshold=100, edgeitems=20)
-    print(np.get_printoptions())
-
-.. parsed-literal::
-
-    {'threshold': 100, 'edgeitems': 20}
-    
-    
-
-
 Initialising by passing arrays
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -795,6 +717,91 @@ consequence of rounding. (This is also the ``numpy`` behaviour.)
     num=5:			 array([0.0, 2.5, 5.0, 7.5, 10.0], dtype=float)
     num=5:			 array([0.0, 2.0, 4.0, 6.0, 8.0], dtype=float)
     num=5:			 array([0, 0, 1, 2, 2, 3, 4], dtype=uint8)
+    
+    
+
+
+Customising array printouts
+---------------------------
+
+``ndarray``\ s are pretty-printed, i.e., if the length is larger than 10
+(default value), then only the first and last three entries will be
+printed. Also note that, as opposed to ``numpy``, the printout always
+contains the ``dtype``.
+
+.. code::
+        
+    # code to be run in micropython
+    
+    import ulab as np
+    
+    a = np.array(range(200))
+    print("a:\t", a)
+
+.. parsed-literal::
+
+    a:	 array([0.0, 1.0, 2.0, ..., 197.0, 198.0, 199.0], dtype=float)
+    
+    
+
+
+set_printoptions
+~~~~~~~~~~~~~~~~
+
+The default values can be overwritten by means of the
+``set_printoptions`` function
+`numpy.set_printoptions <https://numpy.org/doc/1.18/reference/generated/numpy.set_printoptions.html>`__,
+which accepts two keywords arguments, the ``threshold``, and the
+``edgeitems``. The first of these arguments determines the length of the
+longest array that will be printed in full, while the second is the
+number of items that will be printed on the left and right hand side of
+the ellipsis, if the array is longer than ``threshold``.
+
+.. code::
+        
+    # code to be run in micropython
+    
+    import ulab as np
+    
+    a = np.array(range(20))
+    print("a printed with defaults:\t", a)
+    
+    np.set_printoptions(threshold=200)
+    print("\na printed in full:\t\t", a)
+    
+    np.set_printoptions(threshold=10, edgeitems=2)
+    print("\na truncated with 2 edgeitems:\t", a)
+
+.. parsed-literal::
+
+    a printed with defaults:	 array([0.0, 1.0, 2.0, ..., 17.0, 18.0, 19.0], dtype=float)
+    
+    a printed in full:		 array([0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0], dtype=float)
+    
+    a truncated with 2 edgeitems:	 array([0.0, 1.0, ..., 18.0, 19.0], dtype=float)
+    
+    
+
+
+get_printoptions
+~~~~~~~~~~~~~~~~
+
+The set value of the ``threshold`` and ``edgeitems`` can be retrieved by
+calling the ``get_printoptions`` function with no arguments. The
+function returns a dictionary with two keys.
+
+.. code::
+        
+    # code to be run in micropython
+    
+    import ulab as np
+    
+    np.set_printoptions(threshold=100, edgeitems=20)
+    print(np.get_printoptions())
+
+.. parsed-literal::
+
+    {'threshold': 100, 'edgeitems': 20}
     
     
 

--- a/docs/ulab-manual.ipynb
+++ b/docs/ulab-manual.ipynb
@@ -5,8 +5,8 @@
    "execution_count": 1,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2020-04-02T07:43:29.980724Z",
-     "start_time": "2020-04-02T07:43:28.557519Z"
+     "end_time": "2020-05-01T09:27:13.438054Z",
+     "start_time": "2020-05-01T09:27:13.191491Z"
     }
    },
    "outputs": [
@@ -24,11 +24,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2020-04-21T11:03:02.498668Z",
-     "start_time": "2020-04-21T11:03:02.402709Z"
+     "end_time": "2020-05-01T09:27:19.767404Z",
+     "start_time": "2020-05-01T09:27:19.748072Z"
     }
    },
    "outputs": [
@@ -66,7 +66,7 @@
     "author = 'Zoltán Vörös'\n",
     "\n",
     "# The full version, including alpha/beta/rc tags\n",
-    "release = '0.42.0'\n",
+    "release = '0.43.0'\n",
     "\n",
     "\n",
     "# -- General configuration ---------------------------------------------------\n",
@@ -300,11 +300,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 4,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2020-04-21T20:09:18.361457Z",
-     "start_time": "2020-04-21T20:09:18.357762Z"
+     "end_time": "2020-05-01T09:33:51.223397Z",
+     "start_time": "2020-05-01T09:33:51.216685Z"
     }
    },
    "outputs": [],
@@ -318,11 +318,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 5,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2020-04-21T20:09:20.377219Z",
-     "start_time": "2020-04-21T20:09:20.355657Z"
+     "end_time": "2020-05-01T09:33:52.139197Z",
+     "start_time": "2020-05-01T09:33:52.104168Z"
     }
    },
    "outputs": [],
@@ -829,7 +829,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "`ndarray`s are pretty-printed, i.e., if the length is larger than 10, then only the first and last three entries will be printed. Also note that, as opposed to `numpy`, the printout always contains the `dtype`."
+    "### Customising array printouts"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`ndarray`s are pretty-printed, i.e., if the length is larger than 10 (default value), then only the first and last three entries will be printed. Also note that, as opposed to `numpy`, the printout always contains the `dtype`."
    ]
   },
   {
@@ -859,6 +866,88 @@
     "\n",
     "a = np.array(range(200))\n",
     "print(\"a:\\t\", a)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The default values can be overwritten by means of the `set_printoptions` functions [numpy.set_printoptions](#https://numpy.org/doc/1.18/reference/generated/numpy.set_printoptions.html), which accepts two keywords arguments, the `threshold`, and the `edgeitems`. The first of these arguments determines the length of the longest array that will be printed in full, while the second is the number of items that will be printed on the left and right hand side of the ellipsis. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-05-01T09:51:30.390302Z",
+     "start_time": "2020-05-01T09:51:30.379010Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "a printed with defaults:\t array([0.0, 1.0, 2.0, ..., 17.0, 18.0, 19.0], dtype=float)\n",
+      "\n",
+      "a printed in full:\t\t array([0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0], dtype=float)\n",
+      "\n",
+      "a truncated with 2 edgeitems:\t array([0.0, 1.0, ..., 18.0, 19.0], dtype=float)\n",
+      "\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%micropython -unix 1\n",
+    "\n",
+    "import ulab as np\n",
+    "\n",
+    "a = np.array(range(20))\n",
+    "print(\"a printed with defaults:\\t\", a)\n",
+    "\n",
+    "np.set_printoptions(threshold=200)\n",
+    "print(\"\\na printed in full:\\t\\t\", a)\n",
+    "\n",
+    "np.set_printoptions(threshold=10, edgeitems=2)\n",
+    "print(\"\\na truncated with 2 edgeitems:\\t\", a)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The set value of the `threshold` and `edgeitems` can be retrieved by calling the `get_printoptions` function with no arguments:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-05-01T09:48:48.257434Z",
+     "start_time": "2020-05-01T09:48:48.242523Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'threshold': 100, 'edgeitems': 20}\n",
+      "\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%micropython -unix 1\n",
+    "\n",
+    "import ulab as np\n",
+    "\n",
+    "np.set_printoptions(threshold=100, edgeitems=20)\n",
+    "print(np.get_printoptions())"
    ]
   },
   {

--- a/docs/ulab-manual.ipynb
+++ b/docs/ulab-manual.ipynb
@@ -120,11 +120,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 14,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2020-04-21T20:40:41.618721Z",
-     "start_time": "2020-04-21T20:40:38.313434Z"
+     "end_time": "2020-05-01T16:46:00.764988Z",
+     "start_time": "2020-05-01T16:45:57.343808Z"
     }
    },
    "outputs": [],
@@ -829,131 +829,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Customising array printouts"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "`ndarray`s are pretty-printed, i.e., if the length is larger than 10 (default value), then only the first and last three entries will be printed. Also note that, as opposed to `numpy`, the printout always contains the `dtype`."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 448,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2019-10-19T12:09:32.898039Z",
-     "start_time": "2019-10-19T12:09:32.877872Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "a:\t array([0.0, 1.0, 2.0, ..., 197.0, 198.0, 199.0], dtype=float)\n",
-      "\n",
-      "\n"
-     ]
-    }
-   ],
-   "source": [
-    "%%micropython -unix 1\n",
-    "\n",
-    "import ulab as np\n",
-    "\n",
-    "a = np.array(range(200))\n",
-    "print(\"a:\\t\", a)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "The default values can be overwritten by means of the `set_printoptions` functions [numpy.set_printoptions](#https://numpy.org/doc/1.18/reference/generated/numpy.set_printoptions.html), which accepts two keywords arguments, the `threshold`, and the `edgeitems`. The first of these arguments determines the length of the longest array that will be printed in full, while the second is the number of items that will be printed on the left and right hand side of the ellipsis. "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 12,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2020-05-01T09:51:30.390302Z",
-     "start_time": "2020-05-01T09:51:30.379010Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "a printed with defaults:\t array([0.0, 1.0, 2.0, ..., 17.0, 18.0, 19.0], dtype=float)\n",
-      "\n",
-      "a printed in full:\t\t array([0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0], dtype=float)\n",
-      "\n",
-      "a truncated with 2 edgeitems:\t array([0.0, 1.0, ..., 18.0, 19.0], dtype=float)\n",
-      "\n",
-      "\n"
-     ]
-    }
-   ],
-   "source": [
-    "%%micropython -unix 1\n",
-    "\n",
-    "import ulab as np\n",
-    "\n",
-    "a = np.array(range(20))\n",
-    "print(\"a printed with defaults:\\t\", a)\n",
-    "\n",
-    "np.set_printoptions(threshold=200)\n",
-    "print(\"\\na printed in full:\\t\\t\", a)\n",
-    "\n",
-    "np.set_printoptions(threshold=10, edgeitems=2)\n",
-    "print(\"\\na truncated with 2 edgeitems:\\t\", a)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "The set value of the `threshold` and `edgeitems` can be retrieved by calling the `get_printoptions` function with no arguments:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 11,
-   "metadata": {
-    "ExecuteTime": {
-     "end_time": "2020-05-01T09:48:48.257434Z",
-     "start_time": "2020-05-01T09:48:48.242523Z"
-    }
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "{'threshold': 100, 'edgeitems': 20}\n",
-      "\n",
-      "\n"
-     ]
-    }
-   ],
-   "source": [
-    "%%micropython -unix 1\n",
-    "\n",
-    "import ulab as np\n",
-    "\n",
-    "np.set_printoptions(threshold=100, edgeitems=20)\n",
-    "print(np.get_printoptions())"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "### Initialising by passing arrays\n",
     "\n",
     "An `ndarray` can be initialised by supplying another array. This statement is almost trivial, since `ndarray`s are iterables themselves, though it should be pointed out that initialising through arrays is faster, because simply a new copy is created, without inspection, iteration etc. It is also possible to coerce type conversion of the output (with type conversion, the iteration cannot be avoided, therefore, this case will always be slower than straight copying):"
@@ -1331,6 +1206,135 @@
     "\n",
     "# num=5, endpoint=False, dtype=uint8\n",
     "print('num=5:\\t\\t\\t', np.linspace(0, 5, num=7, endpoint=False, dtype=np.uint8))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Customising array printouts"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`ndarray`s are pretty-printed, i.e., if the length is larger than 10 (default value), then only the first and last three entries will be printed. Also note that, as opposed to `numpy`, the printout always contains the `dtype`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 448,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2019-10-19T12:09:32.898039Z",
+     "start_time": "2019-10-19T12:09:32.877872Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "a:\t array([0.0, 1.0, 2.0, ..., 197.0, 198.0, 199.0], dtype=float)\n",
+      "\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%micropython -unix 1\n",
+    "\n",
+    "import ulab as np\n",
+    "\n",
+    "a = np.array(range(200))\n",
+    "print(\"a:\\t\", a)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### set_printoptions\n",
+    "\n",
+    "The default values can be overwritten by means of the `set_printoptions` function [numpy.set_printoptions](https://numpy.org/doc/1.18/reference/generated/numpy.set_printoptions.html), which accepts two keywords arguments, the `threshold`, and the `edgeitems`. The first of these arguments determines the length of the longest array that will be printed in full, while the second is the number of items that will be printed on the left and right hand side of the ellipsis, if the array is longer than `threshold`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-05-01T09:51:30.390302Z",
+     "start_time": "2020-05-01T09:51:30.379010Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "a printed with defaults:\t array([0.0, 1.0, 2.0, ..., 17.0, 18.0, 19.0], dtype=float)\n",
+      "\n",
+      "a printed in full:\t\t array([0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0, 18.0, 19.0], dtype=float)\n",
+      "\n",
+      "a truncated with 2 edgeitems:\t array([0.0, 1.0, ..., 18.0, 19.0], dtype=float)\n",
+      "\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%micropython -unix 1\n",
+    "\n",
+    "import ulab as np\n",
+    "\n",
+    "a = np.array(range(20))\n",
+    "print(\"a printed with defaults:\\t\", a)\n",
+    "\n",
+    "np.set_printoptions(threshold=200)\n",
+    "print(\"\\na printed in full:\\t\\t\", a)\n",
+    "\n",
+    "np.set_printoptions(threshold=10, edgeitems=2)\n",
+    "print(\"\\na truncated with 2 edgeitems:\\t\", a)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### get_printoptions\n",
+    "\n",
+    "The set value of the `threshold` and `edgeitems` can be retrieved by calling the `get_printoptions` function with no arguments. The function returns a dictionary with two keys."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-05-01T09:48:48.257434Z",
+     "start_time": "2020-05-01T09:48:48.242523Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'threshold': 100, 'edgeitems': 20}\n",
+      "\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%micropython -unix 1\n",
+    "\n",
+    "import ulab as np\n",
+    "\n",
+    "np.set_printoptions(threshold=100, edgeitems=20)\n",
+    "print(np.get_printoptions())"
    ]
   },
   {


### PR DESCRIPTION
This PR adds formatting options to `ndarray`s printouts, and implements the feature request in https://github.com/v923z/micropython-ulab/issues/113. 

@jepler I think this is a useful addition, and I have meant to add this feature for a long time. I have tested it on `circuitpython`'s unix port, and haven't seen any glitches. If it is otherwise OK, you can merge it. Documentation is in https://github.com/v923z/micropython-ulab/blob/print/docs/manual/source/ulab.rst#customising-array-printouts Thanks!