### PR TITLE
added equal/not_equal to compare.c

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The `filter` sub-module implements one-dimensional convolution.
 
 ### compare
 
-The `compare` sub-module contains the implementation of the `minimum`, `maximum`, and `clip` functions.
+The `compare` sub-module contains the implementation of the `equal`, `not_equal`, `minimum`, `maximum`, and `clip` functions.
 
 ### extras
 

--- a/code/compare.h
+++ b/code/compare.h
@@ -20,11 +20,13 @@
 enum COMPARE_FUNCTION_TYPE {
     COMPARE_MINIMUM,
     COMPARE_MAXIMUM,
-    COMPARE_CLIP,    
+    COMPARE_CLIP,
 };
 
 extern mp_obj_module_t ulab_compare_module;
 
+MP_DECLARE_CONST_FUN_OBJ_2(compare_equal_obj);
+MP_DECLARE_CONST_FUN_OBJ_2(compare_not_equal_obj);
 MP_DECLARE_CONST_FUN_OBJ_2(compare_minimum_obj);
 MP_DECLARE_CONST_FUN_OBJ_2(compare_maximum_obj);
 MP_DECLARE_CONST_FUN_OBJ_3(compare_clip_obj);

--- a/code/ulab.c
+++ b/code/ulab.c
@@ -31,7 +31,7 @@
 #include "compare.h"
 #include "extras.h"
 
-STATIC MP_DEFINE_STR_OBJ(ulab_version_obj, "0.42.0");
+STATIC MP_DEFINE_STR_OBJ(ulab_version_obj, "0.45.0");
 
 MP_DEFINE_CONST_FUN_OBJ_KW(ndarray_flatten_obj, 1, ndarray_flatten);
 

--- a/docs/manual/source/conf.py
+++ b/docs/manual/source/conf.py
@@ -22,7 +22,7 @@ copyright = '2019-2020, Zoltán Vörös'
 author = 'Zoltán Vörös'
 
 # The full version, including alpha/beta/rc tags
-release = '0.42.0'
+release = '0.45.0'
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/manual/source/ulab.rst
+++ b/docs/manual/source/ulab.rst
@@ -349,6 +349,10 @@ Filter functions
 Comparison of arrays
 --------------------
 
+`equal <#equal,-not_equal>`__
+
+`not_equal <#equal,-not_equal>`__
+
 `minimum <#minimum>`__
 
 `maximum <#maximum>`__
@@ -1353,6 +1357,10 @@ columns the matrix has. This feature will be added in future versions of
            [17, 28, 36]])
 
 
+
+**WARNING:** ``circuitpython`` users should use the ``equal``, and
+``not_equal`` operators instead of ``==``, and ``!=``. See the section
+on `array comparison <#Comparison-of-arrays>`__ for details.
 
 Upcasting
 ~~~~~~~~~
@@ -3487,6 +3495,55 @@ Comparison of arrays
 
 Functions in the ``compare`` module can be called by importing the
 sub-module first.
+
+equal, not_equal
+----------------
+
+``numpy``:
+https://numpy.org/doc/stable/reference/generated/numpy.equal.html
+
+``numpy``:
+https://numpy.org/doc/stable/reference/generated/numpy.not_equal.html
+
+In ``micropython``, equality of arrays or scalars can be established by
+utilising the ``==``, ``!=``, ``<``, ``>``, ``<=``, or ``=>`` binary
+operators. In ``circuitpython``, ``==`` and ``!=`` will produce
+unexpected results. In order to avoid this discrepancy, and to maintain
+compatibility with ``numpy``, ``ulab`` implements the ``equal`` and
+``not_equal`` operators that return the same results, irrespective of
+the ``python`` implementation.
+
+These two functions take two ``ndarray``\ s, or scalars as their
+arguments. No keyword arguments are implemented.
+
+.. code::
+        
+    # code to be run in micropython
+    
+    import ulab as np
+    
+    a = np.array(range(9))
+    b = np.zeros(9)
+    
+    print('a: ', a)
+    print('b: ', b)
+    print('\na == b: ', np.compare.equal(a, b))
+    print('a != b: ', np.compare.not_equal(a, b))
+    
+    # comparison with scalars
+    print('a == 2: ', np.compare.equal(a, 2))
+
+.. parsed-literal::
+
+    a:  array([0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0], dtype=float)
+    b:  array([0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], dtype=float)
+    
+    a == b:  [True, False, False, False, False, False, False, False, False]
+    a != b:  [False, True, True, True, True, True, True, True, True]
+    a == 2:  [False, False, True, False, False, False, False, False, False]
+    
+    
+
 
 minimum
 -------

--- a/docs/ulab-change-log.md
+++ b/docs/ulab-change-log.md
@@ -1,3 +1,9 @@
+Sat, 3 May 2020
+
+version 0.45.0
+
+	add equal/not_equal to the compare module
+	
 Tue, 21 Apr 2020
 
 version 0.42.0

--- a/docs/ulab-manual.ipynb
+++ b/docs/ulab-manual.ipynb
@@ -24,11 +24,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 25,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2020-04-21T11:03:02.498668Z",
-     "start_time": "2020-04-21T11:03:02.402709Z"
+     "end_time": "2020-05-03T08:54:06.757654Z",
+     "start_time": "2020-05-03T08:54:06.750844Z"
     }
    },
    "outputs": [
@@ -66,7 +66,7 @@
     "author = 'Zoltán Vörös'\n",
     "\n",
     "# The full version, including alpha/beta/rc tags\n",
-    "release = '0.42.0'\n",
+    "release = '0.45.0'\n",
     "\n",
     "\n",
     "# -- General configuration ---------------------------------------------------\n",
@@ -120,11 +120,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 27,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2020-04-21T20:40:41.618721Z",
-     "start_time": "2020-04-21T20:40:38.313434Z"
+     "end_time": "2020-05-03T08:59:38.815525Z",
+     "start_time": "2020-05-03T08:59:33.057415Z"
     }
    },
    "outputs": [],
@@ -732,6 +732,10 @@
     "[convolve](#convolve)\n",
     "\n",
     "## Comparison of arrays\n",
+    "\n",
+    "[equal](#equal,-not_equal)\n",
+    "\n",
+    "[not_equal](#equal,-not_equal)\n",
     "\n",
     "[minimum](#minimum)\n",
     "\n",
@@ -2071,11 +2075,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 26,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2020-04-04T19:56:31.111796Z",
-     "start_time": "2020-04-04T19:56:31.091142Z"
+     "end_time": "2020-05-03T08:56:42.903058Z",
+     "start_time": "2020-05-03T08:56:42.890546Z"
     }
    },
    "outputs": [
@@ -2133,6 +2137,13 @@
     "a = array([[1, 2, 3], [4, 5, 6], [7, 8, 6]])\n",
     "b = array([10, 20, 30])\n",
     "a+b"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**WARNING:** `circuitpython` users should use the `equal`, and `not_equal` operators instead of `==`, and `!=`. See the section on [array comparison](#Comparison-of-arrays) for details."
    ]
   },
   {
@@ -4884,6 +4895,63 @@
     "# Comparison of arrays\n",
     "\n",
     "Functions in the `compare` module can be called by importing the sub-module first."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## equal, not_equal\n",
+    "\n",
+    "`numpy`: https://numpy.org/doc/stable/reference/generated/numpy.equal.html\n",
+    "\n",
+    "`numpy`: https://numpy.org/doc/stable/reference/generated/numpy.not_equal.html\n",
+    "\n",
+    "In `micropython`, equality of arrays or scalars can be established by utilising the `==`, `!=`, `<`, `>`, `<=`, or `=>` binary operators. In `circuitpython`, `==` and `!=` will produce unexpected results. In order to avoid this discrepancy, and to maintain compatibility with `numpy`, `ulab` implements the `equal` and `not_equal` operators that return the same results, irrespective of the `python` implementation.\n",
+    "\n",
+    "These two functions take two `ndarray`s, or scalars as their arguments. No keyword arguments are implemented."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-05-03T08:53:02.668348Z",
+     "start_time": "2020-05-03T08:53:02.656130Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "a:  array([0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0], dtype=float)\n",
+      "b:  array([0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], dtype=float)\n",
+      "\n",
+      "a == b:  [True, False, False, False, False, False, False, False, False]\n",
+      "a != b:  [False, True, True, True, True, True, True, True, True]\n",
+      "a == 2:  [False, False, True, False, False, False, False, False, False]\n",
+      "\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%micropython -unix 1\n",
+    "\n",
+    "import ulab as np\n",
+    "\n",
+    "a = np.array(range(9))\n",
+    "b = np.zeros(9)\n",
+    "\n",
+    "print('a: ', a)\n",
+    "print('b: ', b)\n",
+    "print('\\na == b: ', np.compare.equal(a, b))\n",
+    "print('a != b: ', np.compare.not_equal(a, b))\n",
+    "\n",
+    "# comparison with scalars\n",
+    "print('a == 2: ', np.compare.equal(a, 2))"
    ]
   },
   {


### PR DESCRIPTION
This PR offers a workaround for the issue mentioned in https://github.com/v923z/micropython-ulab/pull/86. The `equal` and `not_equal` functions are simply a wrapper for `==`, and `!=`, hence, on `micropython` they deliver identical results, while on `circuitpython`, only `equal/not_equal` yield `numpy`-compatible behaviour, because the `==`, and `!=` operators can't be resolved correctly for non-native types (`ndarray` in this case).

Successfully tested on `circuitpython`'s unix port.

Use cases are listed in the documentation under https://github.com/v923z/micropython-ulab/blob/equal/docs/manual/source/ulab.rst#equal-not_equal

@jepler @dhalbert @tannewt