### PR TITLE
github actions: Fix paths directives

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,9 +4,9 @@ on:
   push:
   pull_request:
     paths:
-    - 'code/'
-    - 'tests/'
-    - '.github/workflows/'
+    - 'code/**'
+    - 'tests/**'
+    - '.github/workflows/**'
   release:
     types: [published]
   check_suite:


### PR DESCRIPTION
I noticed on #122 that no actions were run.  I believe this is because the paths directives had no wildcards, contrary to the examples at https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#onpushpull_requestpaths

Eliminating the paths: restrictions entirely may be an equally valid course of action.