### PR TITLE
fixed incompatibility when enabling '_thread' module from the make command

### DIFF
--- a/code/micropython.mk
+++ b/code/micropython.mk
@@ -19,4 +19,4 @@ SRC_USERMOD += $(USERMODULES_DIR)/ulab.c
 # This is not actually needed in this example.
 CFLAGS_USERMOD += -I$(USERMODULES_DIR)
 
-CFLAGS_EXTRA = -DMODULE_ULAB_ENABLED=1
+override CFLAGS_EXTRA += -DMODULE_ULAB_ENABLED=1


### PR DESCRIPTION
 ulab not compatible with enabling '_thread' module from the make command :
- building ulab with thread enabled in MicroPython :
`$ make -j8 CFLAGS_EXTRA='-DMICROPY_PY_THREAD=1' BOARD=PYBV11 USER_C_MODULES=../../../ulab all`
yields a firmware with '_thread' module but without 'ulab' module, because 'CFLAGS_EXTRA' is used in the make command and in 'ulab/code/micropython.mk', so the value of the last is ignored;
- the solution is to use 'override' and '+=' in in last line of 'ulab/code/micropython.mk' :
`override CFLAGS_EXTRA += -DMODULE_ULAB_ENABLED=1`

Another solution would be enabling '_thread' module by editing MicroPython source code, "../micropython/ports/stm32/mpconfigport.h", line 133, chaning to '#define MICROPY_PY_THREAD           (1)', so no changes to ulab source code.
But it is not so practical as using make command options.