### PR TITLE
Fix Incompatibility between gcc-arm 10.1 and ulab + MicroPython

### DIFF
--- a/code/extras.h
+++ b/code/extras.h
@@ -18,7 +18,7 @@
 
 #if ULAB_EXTRAS_MODULE
 
-mp_obj_module_t ulab_extras_module;
+extern mp_obj_module_t ulab_extras_module;
 
 #endif
 #endif

--- a/code/vectorise.h
+++ b/code/vectorise.h
@@ -24,7 +24,7 @@ typedef struct _vectorized_function_obj_t {
     const mp_obj_type_t *type;
 } vectorized_function_obj_t;
 
-mp_obj_module_t ulab_vectorise_module;
+extern mp_obj_module_t ulab_vectorise_module;
 
 #define ITERATE_VECTOR(type, source, out) do {\
     type *input = (type *)(source)->array->items;\


### PR DESCRIPTION
The [ulab issue #135 "Incompatibility between gcc-arm 10.1 and ulab+MicroPython"](https://github.com/v923z/micropython-ulab/issues/135) can be fixed, following @v923z suggestion, by adding 'extern' in :
- "ulab/code/extras.h", line 21, so it becomes :
`extern mp_obj_module_t ulab_extras_module;`
- "ulab/code/vectorise.h", line 27, so it becomes :
`extern mp_obj_module_t ulab_vectorise_module;`

So gcc-arm 10.1 now compiles ulab + MicroPython.