### PR TITLE
linalg.dot : also accepts 2 vectors of same dimension

### DIFF
--- a/code/linalg.c
+++ b/code/linalg.c
@@ -150,7 +150,7 @@ static mp_obj_t linalg_dot(mp_obj_t _m1, mp_obj_t _m2) {
     if ((m1->m == 1) && (m2->m == 1)) {
         // 2 vectors
         if (m1->array->len != m2->array->len) {
-            mp_raise_ValueError(translate("vectors must have same dimension"));
+            mp_raise_ValueError(translate("vectors must have same lengths"));
         }
         mp_float_t dot = 0.0;
         for (size_t pos=0; pos < m1->array->len; pos++) {


### PR DESCRIPTION
Extend 'ulab.linalg.dot' to accept 2 vectors, so it becomres more similar to [`numpy.dot`](https://numpy.org/doc/stable/reference/generated/numpy.dot.html?highlight=numpy%20dot) and the 1st case from the documentation will be accepted :
- If both a and b are 1-D arrays, it is inner product of vectors (without complex conjugation).
besides the 2nd one :
If both a and b are 2-D arrays, it is matrix multiplication, ...