### PR TITLE
numerical.c : fixed 'out' may be used uninitialized error in function…

### DIFF
--- a/code/numerical/numerical.c
+++ b/code/numerical/numerical.c
@@ -291,11 +291,10 @@ static mp_obj_t numerical_sort_helper(mp_obj_t oin, mp_obj_t axis, uint8_t inpla
     }
 
     ndarray_obj_t *ndarray;
-    mp_obj_t out;
     if(inplace == 1) {
         ndarray = MP_OBJ_TO_PTR(oin);
     } else {
-        out = ndarray_copy(oin);
+        mp_obj_t out = ndarray_copy(oin);
         ndarray = MP_OBJ_TO_PTR(out);
     }
     size_t increment, start_inc, end, N;
@@ -337,7 +336,7 @@ static mp_obj_t numerical_sort_helper(mp_obj_t oin, mp_obj_t axis, uint8_t inpla
     if(inplace == 1) {
         return mp_const_none;
     } else {
-        return out;
+        return MP_OBJ_FROM_PTR(ndarray);
     }
 }
 


### PR DESCRIPTION
numerical.c : fixed 'out' may be used uninitialized error in function 'numerical_sort_helper'.

Some cross compilers/targets (like the one in ESP8266) gives this error :
```
../../../ulab/code/numerical.c:555:14: error: 'out' may be used uninitialized in this function [-Werror=maybe-uninitialized]
     mp_obj_t out;
              ^
...
cc1: all warnings being treated as errors
```
due to the position of 'out' initialization/use.

This PR fix this issue.

Not fixed in this PR is the documentation that says numerical.sort() is in place. I think it was, but that changed.