### PR TITLE
Fix doc build problem in CircuitPython

### DIFF
--- a/code/ndarray.c
+++ b/code/ndarray.c
@@ -167,7 +167,7 @@ mp_uint_t ndarray_print_edgeitems = NDARRAY_PRINT_EDGEITEMS;
 //|         ...
 //|
 //| _ArrayLike = Union[array, List[_float], Tuple[_float], range]
-//| """`ulab.array`, `List[float]`, `Tuple[float]` or `range`"""
+//| """`ulab.array`, ``List[float]``, ``Tuple[float]`` or `range`"""
 //|
 //| int8: _DType
 //| """Type code for signed integers in the range -128 .. 127 inclusive, like the 'b' typecode of `array.array`"""


### PR DESCRIPTION
CircuitPython doc build fails with this diagnostic:
```
/home/runner/work/circuitpython/circuitpython/shared-bindings/ulab/index.rst:220:'any' reference target not found: List[float]
```

Use double backticks instead of single backticks to differentiate between
a reference to a type and just "show in monospace font".

See https://github.com/adafruit/circuitpython/pull/3602 and https://github.com/adafruit/circuitpython/pull/3602/checks?check_run_id=1302834010