### PR TITLE
fix to allow including user.c

### DIFF
--- a/code/ulab.c
+++ b/code/ulab.c
@@ -132,7 +132,7 @@ STATIC const mp_map_elem_t ulab_globals_table[] = {
     #if ULAB_HAS_SCIPY
         { MP_ROM_QSTR(MP_QSTR_scipy), MP_ROM_PTR(&ulab_scipy_module) },
     #endif
-    #if ULAB_USER_MODULE
+    #if ULAB_HAS_USER_MODULE
         { MP_ROM_QSTR(MP_QSTR_user), MP_ROM_PTR(&ulab_user_module) },
     #endif
 };

--- a/code/user/user.c
+++ b/code/user/user.c
@@ -17,7 +17,7 @@
 #include "py/misc.h"
 #include "user.h"
 
-#if ULAB_USER_MODULE
+#if ULAB_HAS_USER_MODULE
 
 //| """This module should hold arbitrary user-defined functions."""
 //|
@@ -80,12 +80,12 @@ static mp_obj_t user_square(mp_obj_t arg) {
 
 MP_DEFINE_CONST_FUN_OBJ_1(user_square_obj, user_square);
 
-STATIC const mp_rom_map_elem_t ulab_user_globals_table[] = {
+static const mp_rom_map_elem_t ulab_user_globals_table[] = {
     { MP_OBJ_NEW_QSTR(MP_QSTR___name__), MP_OBJ_NEW_QSTR(MP_QSTR_user) },
     { MP_OBJ_NEW_QSTR(MP_QSTR_square), (mp_obj_t)&user_square_obj },
 };
 
-STATIC MP_DEFINE_CONST_DICT(mp_module_ulab_user_globals, ulab_user_globals_table);
+static MP_DEFINE_CONST_DICT(mp_module_ulab_user_globals, ulab_user_globals_table);
 
 mp_obj_module_t ulab_user_module = {
     .base = { &mp_type_module },

--- a/code/user/user.h
+++ b/code/user/user.h
@@ -12,8 +12,8 @@
 #ifndef _USER_
 #define _USER_
 
-#include "../ulab.h"
-#include "../ndarray.h"
+#include "ulab.h"
+#include "ndarray.h"
 
 extern mp_obj_module_t ulab_user_module;
 


### PR DESCRIPTION
Solves the issue that constants (e.g. `ULAB_USER_MODULE` -> `ULAB_HAS_USER_MODULE`) have changed, preventing to include `/user/user.c`.