### PR TITLE
Add `np.isinf` tests

### DIFF
--- a/tests/numpy/isinf.py
+++ b/tests/numpy/isinf.py
@@ -1,0 +1,24 @@
+
+from ulab import numpy as np
+
+print('isinf(0): ', np.isinf(0))
+
+a = np.array([1, 2, np.nan])
+print('\n' + '='*20)
+print('a:\n', a)
+print('\nisinf(a):\n', np.isinf(a))
+
+b = np.array([1, 2, np.inf])
+print('\n' + '='*20)
+print('b:\n', b)
+print('\nisinf(b):\n', np.isinf(b))
+
+c = np.array([1, 2, 3], dtype=np.uint16)
+print('\n' + '='*20)
+print('c:\n', c)
+print('\nisinf(c):\n', np.isinf(c))
+
+d = np.eye(5) * 1e999
+print('\n' + '='*20)
+print('d:\n', d)
+print('\nisinf(d):\n', np.isinf(d))

--- a/tests/numpy/isinf.py.exp
+++ b/tests/numpy/isinf.py.exp
@@ -1,0 +1,37 @@
+isinf(0):  False
+
+====================
+a:
+ array([1.0, 2.0, nan], dtype=float64)
+
+isinf(a):
+ array([False, False, False], dtype=bool)
+
+====================
+b:
+ array([1.0, 2.0, inf], dtype=float64)
+
+isinf(b):
+ array([False, False, True], dtype=bool)
+
+====================
+c:
+ array([1, 2, 3], dtype=uint16)
+
+isinf(c):
+ array([False, False, False], dtype=bool)
+
+====================
+d:
+ array([[inf, nan, nan, nan, nan],
+       [nan, inf, nan, nan, nan],
+       [nan, nan, inf, nan, nan],
+       [nan, nan, nan, inf, nan],
+       [nan, nan, nan, nan, inf]], dtype=float64)
+
+isinf(d):
+ array([[True, False, False, False, False],
+       [False, True, False, False, False],
+       [False, False, True, False, False],
+       [False, False, False, True, False],
+       [False, False, False, False, True]], dtype=bool)


### PR DESCRIPTION
I pretty much just copied the examples from your documentation for the tests and added one more example for extremely large float literals. Hopefully this wraps up #274 , I couldn't think of what else to add at the time being.