### PR TITLE
fixes frombuffer implementation glitch

### DIFF
--- a/code/ulab.c
+++ b/code/ulab.c
@@ -33,7 +33,7 @@
 
 #include "user/user.h"
 
-#define ULAB_VERSION 2.3.6
+#define ULAB_VERSION 2.3.7
 #define xstr(s) str(s)
 #define str(s) #s
 #define ULAB_VERSION_STRING xstr(ULAB_VERSION) xstr(-) xstr(ULAB_MAX_DIMS) xstr(D)

--- a/code/ulab_create.c
+++ b/code/ulab_create.c
@@ -669,10 +669,13 @@ mp_obj_t create_frombuffer(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw
                 len = count;
             }
         }
-        ndarray_obj_t *ndarray = ndarray_new_linear_array(len, dtype);
-        uint8_t *array = (uint8_t *)ndarray->array;
+        ndarray_obj_t *ndarray = ndarray_new_linear_array(1, dtype);
+        // at this point, ndarray->len = 1, ndarray->shape[ULAB_MAX_DIMS - 1] = 1
         uint8_t *buffer = bufinfo.buf;
-        memcpy(array, buffer + offset, len * sz);
+        ndarray->array = buffer + offset;
+        // fix the length and shape here
+        ndarray->len = len;
+        ndarray->shape[ULAB_MAX_DIMS - 1] = len;
         return MP_OBJ_FROM_PTR(ndarray);
     }
     return mp_const_none;

--- a/docs/ulab-change-log.md
+++ b/docs/ulab-change-log.md
@@ -1,8 +1,14 @@
+Sun, 14 Feb 2021
+
+version 2.3.7
+
+    fixed frombuffer implementation glitch
+
 Wed, 10 Feb 2021
 
 version 2.3.5
 
-    fixed invisible error in tools_reduce_axes, simplified the implementation of all/any 
+    fixed invisible error in tools_reduce_axes, simplified the implementation of all/any
 
 Tue, 9 Feb 2021
 


### PR DESCRIPTION
`frombuffer` created a new array, contrary to the `numpy` specifications. This led to extra allocation of RAM, and consequently, speed penalty.