### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,14 +54,14 @@ snippet should run equally well in `micropython`, or on a PC.
 
 ```python
 try:
-    from ulab import numpy as np
-    from ulab import scipy as spy
+    from ulab import numpy
+    from ulab import scipy
 except ImportError:
-    import numpy as np
-    import scipy as spy
+    import numpy
+    import scipy.special
 
-x = np.array([1, 2, 3])
-spy.special.erf(x)
+x = numpy.array([1, 2, 3])
+scipy.special.erf(x)
 ```
 
 # Finding help


### PR DESCRIPTION
README.md says
```
try:
    from ulab import numpy as np
    from ulab import scipy as spy
except ImportError:
    import numpy as np
    import scipy as spy

x = np.array([1, 2, 3])
spy.special.erf(x)
```

but in fact, for CPython
```
>>> import scipy as spy
>>> spy.special.erf
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: module 'scipy' has no attribute 'special'
>>> import scipy.special
>>>
```

so I think the README should be
```
try:
    from ulab import numpy
    from ulab import scipy
except ImportError:
    import numpy
    import scipy.special

x = numpy.array([1, 2, 3])
print(x)

print(scipy.special.erf(x))
```