### PR TITLE
fix ndarray_is_dense, eye, ones, full, and zeros for Boolean type

### DIFF
--- a/code/ndarray.c
+++ b/code/ndarray.c
@@ -588,13 +588,13 @@ void ndarray_assign_elements(ndarray_obj_t *ndarray, mp_obj_t iterable, uint8_t 
 bool ndarray_is_dense(ndarray_obj_t *ndarray) {
     // returns true, if the array is dense, false otherwise
     // the array should be dense, if the very first stride can be calculated from shape
-    // TODO: this function could probably be removed
     int32_t stride = ndarray->itemsize;
-    for(uint8_t i=ULAB_MAX_DIMS; i > ULAB_MAX_DIMS-ndarray->ndim; i--) {
+    for(uint8_t i = ULAB_MAX_DIMS - 1; i > ULAB_MAX_DIMS-ndarray->ndim; i--) {
         stride *= ndarray->shape[i];
     }
-    return stride == ndarray->strides[ULAB_MAX_DIMS-ndarray->ndim-1] ? true : false;
+    return stride == ndarray->strides[ULAB_MAX_DIMS-ndarray->ndim] ? true : false;
 }
+
 
 ndarray_obj_t *ndarray_new_ndarray(uint8_t ndim, size_t *shape, int32_t *strides, uint8_t dtype) {
     // Creates the base ndarray with shape, and initialises the values to straight 0s
@@ -1843,7 +1843,7 @@ mp_obj_t ndarray_unary_op(mp_unary_op_t op, mp_obj_t self_in) {
         #if NDARRAY_HAS_UNARY_OP_ABS
         case MP_UNARY_OP_ABS:
             ndarray = ndarray_copy_view(self);
-            // if Booleam, NDARRAY_UINT8, or NDARRAY_UINT16, there is nothing to do
+            // if Boolean, NDARRAY_UINT8, or NDARRAY_UINT16, there is nothing to do
             if(self->dtype == NDARRAY_INT8) {
                 int8_t *array = (int8_t *)ndarray->array;
                 for(size_t i=0; i < self->len; i++, array++) {

--- a/code/ulab.c
+++ b/code/ulab.c
@@ -33,7 +33,7 @@
 
 #include "user/user.h"
 
-#define ULAB_VERSION 2.4.1
+#define ULAB_VERSION 2.4.2
 #define xstr(s) str(s)
 #define str(s) #s
 #define ULAB_VERSION_STRING xstr(ULAB_VERSION) xstr(-) xstr(ULAB_MAX_DIMS) xstr(D)

--- a/code/ulab_create.c
+++ b/code/ulab_create.c
@@ -46,6 +46,14 @@ static mp_obj_t create_zeros_ones_full(mp_obj_t oshape, uint8_t dtype, mp_obj_t 
         ndarray = ndarray_new_dense_ndarray(len, shape, dtype);
     }
     if(value != mp_const_none) {
+        if(dtype == NDARRAY_BOOL) {
+            dtype = NDARRAY_UINT8;
+            if(mp_obj_is_true(value)) {
+                value = mp_obj_new_int(1);
+            } else {
+                value = mp_obj_new_int(0);
+            }
+        }
         for(size_t i=0; i < ndarray->len; i++) {
             mp_binary_set_val_array(dtype, ndarray->array, i, value);
         }
@@ -373,6 +381,9 @@ mp_obj_t create_eye(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) 
         m = mp_obj_get_int(args[1].u_rom_obj);
     }
     ndarray_obj_t *ndarray = ndarray_new_dense_ndarray(2, ndarray_shape_vector(0, 0, n, m), dtype);
+    if(dtype == NDARRAY_BOOL) {
+       dtype = NDARRAY_UINT8;
+   }
     mp_obj_t one = mp_obj_new_int(1);
     size_t i = 0;
     if((args[2].u_int >= 0)) {

--- a/docs/ulab-change-log.md
+++ b/docs/ulab-change-log.md
@@ -1,3 +1,9 @@
+Sun, 21 Feb 2021
+
+version 2.4.2
+
+    fix ndarray_is_dense, eye, ones, full, and zeros for Boolean type
+
 Sat, 13 Feb 2021
 
 version 2.4.1


### PR DESCRIPTION
fixes errors first found on the `legacy` branch: https://github.com/v923z/micropython-ulab/issues/331, https://github.com/v923z/micropython-ulab/issues/328