### PR TITLE
USER_C_MODULES cmake support for rp2 and esp32

### DIFF
--- a/code/usermod.cmake
+++ b/code/usermod.cmake
@@ -1,0 +1,21 @@
+add_library(usermod_ulab INTERFACE)
+
+file(GLOB_RECURSE ULAB_SOURCES ${CMAKE_CURRENT_LIST_DIR}/*.c)
+
+message(WARNING ${CMAKE_CURRENT_LIST_DIR})
+message(WARNING ${ULAB_SOURCES})
+
+target_sources(usermod_ulab INTERFACE
+    ${ULAB_SOURCES}
+)
+
+target_include_directories(usermod_ulab INTERFACE
+    ${CMAKE_CURRENT_LIST_DIR}
+)
+
+target_compile_definitions(usermod_ulab INTERFACE
+    -DMODULE_ULAB_ENABLED=1
+)
+
+target_link_libraries(usermod INTERFACE usermod_ulab)
+


### PR DESCRIPTION
This change introduces `usermod.cmake`, the CMake configuration required to make this library compatible with the CMake build systems for the rp2 (Raspberry Pi Pico/RP2040) and esp32 ports of MicroPython.

This is effectively 1:1 in functionality with `micropython.mk` and defines the source files, include directories and compile arguments needed to build the module.

See https://github.com/micropython/micropython/pull/6960 for discussion.

This is raised as a draft since the supporting framework has not yet been merged into MicroPython.