### PR TITLE
fix array initialisation with empty iterables

### DIFF
--- a/code/ulab.c
+++ b/code/ulab.c
@@ -34,7 +34,7 @@
 #include "user/user.h"
 #include "utils/utils.h"
 
-#define ULAB_VERSION 2.8.0
+#define ULAB_VERSION 2.8.1
 #define xstr(s) str(s)
 #define str(s) #s
 #define ULAB_VERSION_STRING xstr(ULAB_VERSION) xstr(-) xstr(ULAB_MAX_DIMS) xstr(D)

--- a/docs/ulab-change-log.md
+++ b/docs/ulab-change-log.md
@@ -1,3 +1,9 @@
+Tue, 18 May 2021
+
+version 2.8.1
+
+    fix array initialisation/print with empty iterables
+
 Sun, 16 May 2021
 
 version 2.8.0


### PR DESCRIPTION
This PR partially solves the issue discovered in https://github.com/v923z/micropython-ulab/issues/389: if an empty iterable is passed to the constructor, a proper `ndarray` will now be created; printouts are also fixed.