### PR TITLE
Empty fix

### DIFF
--- a/code/numpy/numerical/numerical.c
+++ b/code/numpy/numerical/numerical.c
@@ -69,6 +69,13 @@ static mp_obj_t numerical_all_any(mp_obj_t oin, mp_obj_t axis, uint8_t optype) {
     if(mp_obj_is_type(oin, &ulab_ndarray_type)) {
         ndarray_obj_t *ndarray = MP_OBJ_TO_PTR(oin);
         uint8_t *array = (uint8_t *)ndarray->array;
+        if(ndarray->len == 0) { // return immediately with empty arrays
+        if(optype == NUMERICAL_ALL) {
+                return mp_const_true;
+            } else {
+                return mp_const_false;
+            }
+        }
         // always get a float, so that we don't have to resolve the dtype later
         mp_float_t (*func)(void *) = ndarray_get_float_function(ndarray->dtype);
         ndarray_obj_t *results = NULL;

--- a/code/numpy/numerical/numerical.c
+++ b/code/numpy/numerical/numerical.c
@@ -988,7 +988,12 @@ mp_obj_t numerical_median(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_
         mp_raise_TypeError(translate("median argument must be an ndarray"));
     }
 
-    ndarray_obj_t *ndarray = numerical_sort_helper(args[0].u_obj, args[1].u_obj, 0);
+    ndarray_obj_t *ndarray = MP_OBJ_TO_PTR(args[0].u_obj);
+    if(ndarray->len == 0) {
+        return mp_obj_new_float(MICROPY_FLOAT_CONST(NAN));
+    }
+
+    ndarray = numerical_sort_helper(args[0].u_obj, args[1].u_obj, 0);
 
     if((args[1].u_obj == mp_const_none) || (ndarray->ndim == 1)) {
         // at this point, the array holding the sorted values should be flat

--- a/code/numpy/numerical/numerical.c
+++ b/code/numpy/numerical/numerical.c
@@ -990,7 +990,7 @@ mp_obj_t numerical_median(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_
 
     ndarray_obj_t *ndarray = MP_OBJ_TO_PTR(args[0].u_obj);
     if(ndarray->len == 0) {
-        return mp_obj_new_float(MICROPY_FLOAT_CONST(NAN));
+        return mp_obj_new_float(MICROPY_FLOAT_CONST(MICROPY_FLOAT_C_FUN(sqrt)(-1.0)));
     }
 
     ndarray = numerical_sort_helper(args[0].u_obj, args[1].u_obj, 0);

--- a/code/ulab.c
+++ b/code/ulab.c
@@ -34,7 +34,7 @@
 #include "user/user.h"
 #include "utils/utils.h"
 
-#define ULAB_VERSION 2.8.1
+#define ULAB_VERSION 2.8.2
 #define xstr(s) str(s)
 #define str(s) #s
 #define ULAB_VERSION_STRING xstr(ULAB_VERSION) xstr(-) xstr(ULAB_MAX_DIMS) xstr(D)

--- a/docs/ulab-change-log.md
+++ b/docs/ulab-change-log.md
@@ -1,3 +1,9 @@
+Sat, 22 May 2021
+
+version 2.8.2
+
+    fix all/any/median for empty arrays
+
 Tue, 18 May 2021
 
 version 2.8.1


### PR DESCRIPTION
This PR fixes the return values for `all/any/median`, if the input is an empty array.