### PR TITLE
implement ndarray properties

### DIFF
--- a/code/micropython.mk
+++ b/code/micropython.mk
@@ -9,6 +9,7 @@ SRC_USERMOD += $(USERMODULES_DIR)/scipy/special/special.c
 SRC_USERMOD += $(USERMODULES_DIR)/ndarray_operators.c
 SRC_USERMOD += $(USERMODULES_DIR)/ulab_tools.c
 SRC_USERMOD += $(USERMODULES_DIR)/ndarray.c
+SRC_USERMOD += $(USERMODULES_DIR)/ndarray_properties.c
 SRC_USERMOD += $(USERMODULES_DIR)/numpy/approx/approx.c
 SRC_USERMOD += $(USERMODULES_DIR)/numpy/compare/compare.c
 SRC_USERMOD += $(USERMODULES_DIR)/ulab_create.c

--- a/code/ndarray_properties.c
+++ b/code/ndarray_properties.c
@@ -1,0 +1,71 @@
+
+/*
+ * This file is part of the micropython-ulab project,
+ *
+ * https://github.com/v923z/micropython-ulab
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021 Zoltán Vörös
+ *
+*/
+
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "py/obj.h"
+#include "py/runtime.h"
+
+#include "ulab.h"
+#include "ndarray.h"
+
+#if !CIRCUITPY
+
+// a somewhat hackish implementation of property getters/setters;
+// this functions is hooked into the attr member of ndarray
+void ndarray_properties_attr(mp_obj_t self_in, qstr attr, mp_obj_t *dest) {
+    if (dest[0] == MP_OBJ_NULL) {
+        switch(attr) {
+            #if NDARRAY_HAS_DTYPE
+            case MP_QSTR_dtype:
+                dest[0] = ndarray_dtype(self_in);
+                break;
+            #endif
+            #if NDARRAY_HAS_ITEMSIZE
+            case MP_QSTR_itemsize:
+                dest[0] = ndarray_itemsize(self_in);
+                break;
+            #endif
+            #if NDARRAY_HAS_ITEMSIZE
+            case MP_QSTR_shape:
+                dest[0] = ndarray_shape(self_in);
+                break;
+            #endif
+            #if NDARRAY_HAS_SIZE
+            case MP_QSTR_size:
+                dest[0] = ndarray_size(self_in);
+                break;
+            #endif
+            #if NDARRAY_HAS_STRIDES
+            case MP_QSTR_strides:
+                dest[0] = ndarray_strides(self_in);
+                break;
+            #endif
+            default:
+                return;
+        }
+    } else {
+        return;
+        // if (dest[1]) {
+        //     switch(attr) {
+        //         default:
+        //             return;
+        //     }
+
+        //     dest[0] = MP_OBJ_NULL;
+        // }
+    }
+}
+
+#endif /* CIRCUITPY */

--- a/code/ndarray_properties.h
+++ b/code/ndarray_properties.h
@@ -1,13 +1,13 @@
 
 /*
- * This file is part of the micropython-ulab project, 
+ * This file is part of the micropython-ulab project,
  *
  * https://github.com/v923z/micropython-ulab
  *
  * The MIT License (MIT)
  *
  * Copyright (c) 2020 Jeff Epler for Adafruit Industries
- *               2020 Zoltán Vörös   
+ *               2020 Zoltán Vörös
 */
 
 #ifndef _NDARRAY_PROPERTIES_
@@ -86,4 +86,9 @@ MP_DEFINE_CONST_FUN_OBJ_1(ndarray_size_obj, ndarray_size);
 MP_DEFINE_CONST_FUN_OBJ_1(ndarray_strides_obj, ndarray_strides);
 
 #endif /* CIRCUITPY */
+
+#if !CIRCUITPY
+void ndarray_properties_attr(mp_obj_t , qstr , mp_obj_t *);
+#endif
+
 #endif

--- a/code/ulab.c
+++ b/code/ulab.c
@@ -34,7 +34,7 @@
 #include "user/user.h"
 #include "utils/utils.h"
 
-#define ULAB_VERSION 2.9.0
+#define ULAB_VERSION 2.10.0
 #define xstr(s) str(s)
 #define str(s) #s
 #define ULAB_VERSION_STRING xstr(ULAB_VERSION) xstr(-) xstr(ULAB_MAX_DIMS) xstr(D)
@@ -58,23 +58,8 @@ STATIC const mp_rom_map_elem_t ulab_ndarray_locals_dict_table[] = {
     #if NDARRAY_HAS_COPY
         { MP_ROM_QSTR(MP_QSTR_copy), MP_ROM_PTR(&ndarray_copy_obj) },
     #endif
-    #if NDARRAY_HAS_DTYPE
-        { MP_ROM_QSTR(MP_QSTR_dtype), MP_ROM_PTR(&ndarray_dtype_obj) },
-    #endif
     #if NDARRAY_HAS_FLATTEN
         { MP_ROM_QSTR(MP_QSTR_flatten), MP_ROM_PTR(&ndarray_flatten_obj) },
-    #endif
-    #if NDARRAY_HAS_ITEMSIZE
-        { MP_ROM_QSTR(MP_QSTR_itemsize), MP_ROM_PTR(&ndarray_itemsize_obj) },
-    #endif
-    #if NDARRAY_HAS_SHAPE
-        { MP_ROM_QSTR(MP_QSTR_shape), MP_ROM_PTR(&ndarray_shape_obj) },
-    #endif
-    #if NDARRAY_HAS_SIZE
-        { MP_ROM_QSTR(MP_QSTR_size), MP_ROM_PTR(&ndarray_size_obj) },
-    #endif
-    #if NDARRAY_HAS_STRIDES
-        { MP_ROM_QSTR(MP_QSTR_strides), MP_ROM_PTR(&ndarray_strides_obj) },
     #endif
     #if NDARRAY_HAS_TOBYTES
         { MP_ROM_QSTR(MP_QSTR_tobytes), MP_ROM_PTR(&ndarray_tobytes_obj) },
@@ -105,6 +90,9 @@ const mp_obj_type_t ulab_ndarray_type = {
     #endif
     #if NDARRAY_HAS_BINARY_OPS
     .binary_op = ndarray_binary_op,
+    #endif
+    #ifndef CIRCUITPY
+    .attr = ndarray_properties_attr,
     #endif
     .buffer_p = { .get_buffer = ndarray_get_buffer, },
     .locals_dict = (mp_obj_dict_t*)&ulab_ndarray_locals_dict,

--- a/docs/ulab-change-log.md
+++ b/docs/ulab-change-log.md
@@ -1,3 +1,9 @@
+Tue, 8 Jun 2021
+
+version 2.10.0
+
+    implement property getter/setter for micropython
+
 Thu, 3 Jun 2021
 
 version 2.9.0


### PR DESCRIPTION
This PR implements the `ndarray` properties by means of the `attr` member of the `ulab_ndarray_type`. The original idea was posted in https://github.com/micropython/micropython/pull/5648#issuecomment-831531599 