### PR TITLE
implement ndarray.shape assignment

### DIFF
--- a/code/ndarray.h
+++ b/code/ndarray.h
@@ -173,6 +173,7 @@ mp_obj_t ndarray_shape(mp_obj_t );
 mp_obj_t ndarray_strides(mp_obj_t );
 
 #if NDARRAY_HAS_RESHAPE
+mp_obj_t ndarray_reshape_core(mp_obj_t , mp_obj_t , bool );
 mp_obj_t ndarray_reshape(mp_obj_t , mp_obj_t );
 MP_DECLARE_CONST_FUN_OBJ_2(ndarray_reshape_obj);
 #endif

--- a/code/ndarray_properties.c
+++ b/code/ndarray_properties.c
@@ -81,7 +81,19 @@ void ndarray_properties_attr(mp_obj_t self_in, qstr attr, mp_obj_t *dest) {
                 break;
         }
     } else {
-        return;
+        if(dest[1]) {
+            switch(attr) {
+                #if NDARRAY_HAS_RESHAPE
+                case MP_QSTR_shape:
+                    ndarray_reshape_core(self_in, dest[1], 1);
+                    break;
+                #endif
+                default:
+                    return;
+                    break;
+            }
+            dest[0] = MP_OBJ_NULL;
+        }
     }
 }
 

--- a/code/ulab.c
+++ b/code/ulab.c
@@ -34,7 +34,7 @@
 #include "user/user.h"
 #include "utils/utils.h"
 
-#define ULAB_VERSION 3.0.1
+#define ULAB_VERSION 3.1.0
 #define xstr(s) str(s)
 #define str(s) #s
 #define ULAB_VERSION_STRING xstr(ULAB_VERSION) xstr(-) xstr(ULAB_MAX_DIMS) xstr(D)

--- a/docs/manual/source/conf.py
+++ b/docs/manual/source/conf.py
@@ -27,7 +27,7 @@ copyright = '2019-2021, Zoltán Vörös and contributors'
 author = 'Zoltán Vörös'
 
 # The full version, including alpha/beta/rc tags
-release = '3.0.1'
+release = '3.1.0'
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/manual/source/ulab-ndarray.rst
+++ b/docs/manual/source/ulab-ndarray.rst
@@ -1128,6 +1128,11 @@ consistent with the old, a ``ValueError`` exception will be raised.
     
 
 
+.. code::
+
+    # code to be run in CPython
+    
+    Note that `ndarray.reshape()` can also be called by assigning to `ndarray.shape`.
 .shape
 ~~~~~~
 
@@ -1149,7 +1154,7 @@ array along each axis.
     
     b= np.array([[1, 2], [3, 4]], dtype=np.int8)
     print("\nb:\n", b)
-    print("shape of b:", b.shape
+    print("shape of b:", b.shape)
 
 .. parsed-literal::
 
@@ -1161,6 +1166,34 @@ array along each axis.
      array([[1, 2],
            [3, 4]], dtype=int8)
     shape of b: (2, 2)
+    
+    
+
+
+By assigning a tuple to the ``.shape`` property, the array can be
+``reshape``\ d:
+
+.. code::
+        
+    # code to be run in micropython
+    
+    from ulab import numpy as np
+    
+    a = np.array([1, 2, 3, 4, 5, 6, 7, 8, 9])
+    print('a:\n', a)
+    
+    a.shape = (3, 3)
+    print('\na:\n', a)
+
+.. parsed-literal::
+
+    a:
+     array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0], dtype=float64)
+    
+    a:
+     array([[1.0, 2.0, 3.0],
+           [4.0, 5.0, 6.0],
+           [7.0, 8.0, 9.0]], dtype=float64)
     
     
 

--- a/docs/ulab-change-log.md
+++ b/docs/ulab-change-log.md
@@ -1,3 +1,9 @@
+Sat, 19 Jun 2021
+
+version 3.1.0
+
+    ndarray.shape can now be assigned to
+
 Thu, 17 Jun 2021
 
 version 3.0.1

--- a/docs/ulab-convert.ipynb
+++ b/docs/ulab-convert.ipynb
@@ -61,7 +61,7 @@
     "author = 'Zoltán Vörös'\n",
     "\n",
     "# The full version, including alpha/beta/rc tags\n",
-    "release = '3.0.1'\n",
+    "release = '3.1.0'\n",
     "\n",
     "\n",
     "# -- General configuration ---------------------------------------------------\n",

--- a/docs/ulab-ndarray.ipynb
+++ b/docs/ulab-ndarray.ipynb
@@ -1677,6 +1677,15 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Note that `ndarray.reshape()` can also be called by assigning to `ndarray.shape`. "
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1725,7 +1734,39 @@
     "\n",
     "b= np.array([[1, 2], [3, 4]], dtype=np.int8)\n",
     "print(\"\\nb:\\n\", b)\n",
-    "print(\"shape of b:\", b.shape"
+    "print(\"shape of b:\", b.shape)"
+   ]
+  },
+  {
+   "source": [
+    "By assigning a tuple to the `.shape` property, the array can be `reshape`d:"
+   ],
+   "cell_type": "markdown",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "a:\n array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0], dtype=float64)\n\na:\n array([[1.0, 2.0, 3.0],\n       [4.0, 5.0, 6.0],\n       [7.0, 8.0, 9.0]], dtype=float64)\n\n\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%micropython -unix 1\n",
+    "\n",
+    "from ulab import numpy as np\n",
+    "\n",
+    "a = np.array([1, 2, 3, 4, 5, 6, 7, 8, 9])\n",
+    "print('a:\\n', a)\n",
+    "\n",
+    "a.shape = (3, 3)\n",
+    "print('\\na:\\n', a)"
    ]
   },
   {


### PR DESCRIPTION
This PR implements direct assignment to `ndarray.shape`.