### PR TITLE
Build all dimensions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,7 @@ jobs:
             os:
                 - ubuntu-16.04
                 - macos-10.14
+            dims: [2, 3, 4]
     runs-on: ${{ matrix.os }}
     steps:
     - name: Dump GitHub context
@@ -46,7 +47,7 @@ jobs:
         path: micropython
 
     - name: Run build.sh
-      run: ./build.sh
+      run: ./build.sh ${{ matrix.dims }}
 
   circuitpython:
     strategy:
@@ -54,6 +55,7 @@ jobs:
             os:
                 - ubuntu-20.04
                 - macos-10.14
+            dims: [2, 3, 4]
     runs-on: ${{ matrix.os }}
     steps:
     - name: Dump GitHub context
@@ -85,4 +87,4 @@ jobs:
         python3 -mpip install -r requirements_cp_dev.txt
 
     - name: Run build-cp.sh
-      run: ./build-cp.sh
+      run: ./build-cp.sh ${{ matrix.dims }}

--- a/code/ulab.h
+++ b/code/ulab.h
@@ -40,7 +40,9 @@
 
 // The maximum number of dimensions the firmware should be able to support
 // Possible values lie between 1, and 4, inclusive
+#ifndef ULAB_MAX_DIMS
 #define ULAB_MAX_DIMS                       2
+#endif
 
 // By setting this constant to 1, iteration over array dimensions will be implemented
 // as a function (ndarray_rewind_array), instead of writing out the loops in macros


### PR DESCRIPTION
... actually, build 2, 3, and 4 dimensions.  I'll file a separate issue showing why I didn't enable building 1D.

This:
 * changes the build scripts so that they take a positional argument, optional, defaulting to 2: `./build.sh 3`
 * adds some dimension-linked tests;  Say you're doing a 3D build, it will run the 1d, 2d, and 3d tests in addition to the "non-dimensoined" tests.

I suspect some existing tests will need to be moved into 2d; we can also introduce a 2-level structure if it makes sense, e.g., `2d/scipy`, `3d/numpy`, or whatever is most useful.  No existing tests had to be moved to 2d in part because of not enabling a 1d build in the CI yet.