### PR TITLE
fix compilation for 1D

### DIFF
--- a/code/ndarray.c
+++ b/code/ndarray.c
@@ -396,11 +396,13 @@ static void ndarray_print_row(const mp_print_t *print, ndarray_obj_t * ndarray, 
     mp_print_str(print, "]");
 }
 
+#if ULAB_MAX_DIMS > 1
 static void ndarray_print_bracket(const mp_print_t *print, const size_t condition, const size_t shape, const char *string) {
     if(condition < shape) {
         mp_print_str(print, string);
     }
 }
+#endif
 
 void ndarray_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t kind) {
     (void)kind;
@@ -411,9 +413,13 @@ void ndarray_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t ki
         mp_print_str(print, "[]");
         if(self->ndim > 1) {
             mp_print_str(print, ", shape=(");
+            #if ULAB_MAX_DIMS > 1
             for(uint8_t ndim = self->ndim; ndim > 1; ndim--) {
                 mp_printf(MP_PYTHON_PRINTER, "%d,", self->shape[ULAB_MAX_DIMS - ndim]);
             }
+            #else
+            mp_printf(MP_PYTHON_PRINTER, "%d,", self->shape[0]);
+            #endif
             mp_printf(MP_PYTHON_PRINTER, "%d)", self->shape[ULAB_MAX_DIMS - 1]);
         }
     } else {

--- a/code/ndarray_properties.c
+++ b/code/ndarray_properties.c
@@ -89,10 +89,12 @@ void ndarray_properties_attr(mp_obj_t self_in, qstr attr, mp_obj_t *dest) {
     } else {
         if(dest[1]) {
             switch(attr) {
+                #if ULAB_MAX_DIMS > 1
                 #if NDARRAY_HAS_RESHAPE
                 case MP_QSTR_shape:
                     ndarray_reshape_core(self_in, dest[1], 1);
                     break;
+                #endif
                 #endif
                 default:
                     return;

--- a/code/numpy/numerical.c
+++ b/code/numpy/numerical.c
@@ -579,6 +579,7 @@ static mp_obj_t numerical_sort_helper(mp_obj_t oin, mp_obj_t axis, uint8_t inpla
     int8_t ax = 0;
     if(axis == mp_const_none) {
         // flatten the array
+        #if ULAB_MAX_DIMS > 1
         for(uint8_t i=0; i < ULAB_MAX_DIMS - 1; i++) {
             ndarray->shape[i] = 0;
             ndarray->strides[i] = 0;
@@ -586,6 +587,7 @@ static mp_obj_t numerical_sort_helper(mp_obj_t oin, mp_obj_t axis, uint8_t inpla
         ndarray->shape[ULAB_MAX_DIMS - 1] = ndarray->len;
         ndarray->strides[ULAB_MAX_DIMS - 1] = ndarray->itemsize;
         ndarray->ndim = 1;
+        #endif
     } else {
         ax = mp_obj_get_int(axis);
         if(ax < 0) ax += ndarray->ndim;

--- a/code/numpy/numerical.h
+++ b/code/numpy/numerical.h
@@ -201,7 +201,7 @@
 } while(0)
 
 #define RUN_MEAN_STD(type, array, rarray, ss, div, isStd) do {\
-    RUN_MEAN_STD1(type, (array), (results), (rarray), (ss), (div), (isStd));\
+    RUN_MEAN_STD1(type, (array), (rarray), (ss), (div), (isStd));\
 } while(0)
 
 #define RUN_ARGMIN(ndarray, type, array, results, rarray, shape, strides, index, op) do {\

--- a/code/numpy/numpy.c
+++ b/code/numpy/numpy.c
@@ -146,7 +146,9 @@ static const mp_rom_map_elem_t ulab_numpy_globals_table[] = {
         { MP_ROM_QSTR(MP_QSTR_concatenate), (mp_obj_t)&create_concatenate_obj },
     #endif
     #if ULAB_NUMPY_HAS_DIAG
-        { MP_ROM_QSTR(MP_QSTR_diag), (mp_obj_t)&create_diag_obj },
+        #if ULAB_MAX_DIMS > 1
+            { MP_ROM_QSTR(MP_QSTR_diag), (mp_obj_t)&create_diag_obj },
+        #endif
     #endif
     #if ULAB_NUMPY_HAS_EMPTY
         { MP_ROM_QSTR(MP_QSTR_empty), (mp_obj_t)&create_zeros_obj },
@@ -229,10 +231,14 @@ static const mp_rom_map_elem_t ulab_numpy_globals_table[] = {
         { MP_OBJ_NEW_QSTR(MP_QSTR_diff), (mp_obj_t)&numerical_diff_obj },
     #endif
     #if ULAB_NUMPY_HAS_DOT
-        { MP_OBJ_NEW_QSTR(MP_QSTR_dot), (mp_obj_t)&transform_dot_obj },
+        #if ULAB_MAX_DIMS > 1
+            { MP_OBJ_NEW_QSTR(MP_QSTR_dot), (mp_obj_t)&transform_dot_obj },
+        #endif
     #endif
     #if ULAB_NUMPY_HAS_TRACE
-    { MP_ROM_QSTR(MP_QSTR_trace), (mp_obj_t)&stats_trace_obj },
+        #if ULAB_MAX_DIMS > 1
+            { MP_ROM_QSTR(MP_QSTR_trace), (mp_obj_t)&stats_trace_obj },
+        #endif
     #endif
     #if ULAB_NUMPY_HAS_FLIP
         { MP_OBJ_NEW_QSTR(MP_QSTR_flip), (mp_obj_t)&numerical_flip_obj },

--- a/code/numpy/transform.c
+++ b/code/numpy/transform.c
@@ -20,7 +20,7 @@
 #include "../ulab_tools.h"
 #include "transform.h"
 
-
+#if ULAB_MAX_DIMS > 1
 #if ULAB_NUMPY_HAS_DOT
 //| def dot(m1: ulab.numpy.ndarray, m2: ulab.numpy.ndarray) -> Union[ulab.numpy.ndarray, _float]:
 //|    """
@@ -86,4 +86,5 @@ mp_obj_t transform_dot(mp_obj_t _m1, mp_obj_t _m2) {
 }
 
 MP_DEFINE_CONST_FUN_OBJ_2(transform_dot_obj, transform_dot);
+#endif
 #endif

--- a/code/ulab.c
+++ b/code/ulab.c
@@ -33,7 +33,7 @@
 #include "user/user.h"
 #include "utils/utils.h"
 
-#define ULAB_VERSION 3.3.2
+#define ULAB_VERSION 3.3.3
 #define xstr(s) str(s)
 #define str(s) #s
 #define ULAB_VERSION_STRING xstr(ULAB_VERSION) xstr(-) xstr(ULAB_MAX_DIMS) xstr(D)

--- a/code/ulab.h
+++ b/code/ulab.h
@@ -40,7 +40,7 @@
 
 // The maximum number of dimensions the firmware should be able to support
 // Possible values lie between 1, and 4, inclusive
-#define ULAB_MAX_DIMS                       2
+#define ULAB_MAX_DIMS                       1
 
 // By setting this constant to 1, iteration over array dimensions will be implemented
 // as a function (ndarray_rewind_array), instead of writing out the loops in macros

--- a/code/ulab.h
+++ b/code/ulab.h
@@ -40,12 +40,14 @@
 
 // The maximum number of dimensions the firmware should be able to support
 // Possible values lie between 1, and 4, inclusive
-#define ULAB_MAX_DIMS                       1
+#define ULAB_MAX_DIMS                       2
 
 // By setting this constant to 1, iteration over array dimensions will be implemented
 // as a function (ndarray_rewind_array), instead of writing out the loops in macros
 // This reduces firmware size at the expense of speed
+#ifndef ULAB_HAS_FUNCTION_ITERATOR
 #define ULAB_HAS_FUNCTION_ITERATOR          (0)
+#endif
 
 // If NDARRAY_IS_ITERABLE is 1, the ndarray object defines its own iterator function
 // This option saves approx. 250 bytes of flash space

--- a/code/ulab_create.c
+++ b/code/ulab_create.c
@@ -252,6 +252,7 @@ mp_obj_t create_concatenate(size_t n_args, const mp_obj_t *pos_args, mp_map_t *k
 MP_DEFINE_CONST_FUN_OBJ_KW(create_concatenate_obj, 1, create_concatenate);
 #endif
 
+#if ULAB_MAX_DIMS > 1
 #if ULAB_NUMPY_HAS_DIAG
 mp_obj_t create_diag(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     static const mp_arg_t allowed_args[] = {
@@ -314,7 +315,6 @@ mp_obj_t create_diag(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args)
 MP_DEFINE_CONST_FUN_OBJ_KW(create_diag_obj, 1, create_diag);
 #endif /* ULAB_NUMPY_HAS_DIAG */
 
-#if ULAB_MAX_DIMS > 1
 #if ULAB_NUMPY_HAS_EYE
 mp_obj_t create_eye(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     static const mp_arg_t allowed_args[] = {

--- a/docs/ulab-change-log.md
+++ b/docs/ulab-change-log.md
@@ -1,3 +1,9 @@
+Fri, 23 Jul 2021
+
+version 3.3.3
+
+    fix compilation for one dimension
+
 Thu, 22 Jul 2021
 
 version 3.3.2
@@ -21,7 +27,7 @@ Tue, 13 Jul 2021
 version 3.2.0
 
     add flatiter/flat to ndarray methods
-    
+
 Tue, 22 Jun 2021
 
 version 3.1.1


### PR DESCRIPTION
This PR re-introduces the option of compiling with ULAB_MAX_DIMS = 1, and should close https://github.com/v923z/micropython-ulab/issues/430 .