### PR TITLE
ndarray: drop compat workaround for circuitpython

### DIFF
--- a/code/ndarray.c
+++ b/code/ndarray.c
@@ -925,18 +925,6 @@ mp_obj_t ndarray_array_constructor(size_t n_args, const mp_obj_t *pos_args, mp_m
 }
 MP_DEFINE_CONST_FUN_OBJ_KW(ndarray_array_constructor_obj, 1, ndarray_array_constructor);
 
-#ifdef CIRCUITPY
-mp_obj_t ndarray_make_new(const mp_obj_type_t *type, size_t n_args, const mp_obj_t *args, mp_map_t *kw_args) {
-    (void) type;
-    mp_arg_check_num(n_args, kw_args, 1, 2, true);
-    size_t n_kw = 0;
-    if (kw_args != 0) {
-        n_kw = kw_args->used;
-    }
-    mp_map_init_fixed_table(kw_args, n_kw, args + n_args);
-    return ndarray_make_new_core(type, n_args, n_kw, args, kw_args);
-}
-#else
 mp_obj_t ndarray_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args) {
     (void) type;
     mp_arg_check_num(n_args, n_kw, 1, 2, true);
@@ -944,7 +932,6 @@ mp_obj_t ndarray_make_new(const mp_obj_type_t *type, size_t n_args, size_t n_kw,
     mp_map_init_fixed_table(&kw_args, n_kw, args + n_args);
     return ndarray_make_new_core(type, n_args, n_kw, args, &kw_args);
 }
-#endif
 
 // broadcasting is used at a number of places, always include
 bool ndarray_can_broadcast(ndarray_obj_t *lhs, ndarray_obj_t *rhs, uint8_t *ndim, size_t *shape, int32_t *lstrides, int32_t *rstrides) {

--- a/code/ndarray.h
+++ b/code/ndarray.h
@@ -103,11 +103,7 @@ typedef struct _dtype_obj_t {
 
 void ndarray_dtype_print(const mp_print_t *, mp_obj_t , mp_print_kind_t );
 
-#ifdef CIRCUITPY
-mp_obj_t ndarray_dtype_make_new(const mp_obj_type_t *type, size_t n_args, const mp_obj_t *args, mp_map_t *kw_args);
-#else
 mp_obj_t ndarray_dtype_make_new(const mp_obj_type_t *, size_t , size_t , const mp_obj_t *);
-#endif /* CIRCUITPY */
 #endif /* ULAB_HAS_DTYPE_OBJECT */
 
 extern const mp_obj_type_t ndarray_flatiter_type;
@@ -145,11 +141,7 @@ ndarray_obj_t *ndarray_copy_view(ndarray_obj_t *);
 void ndarray_copy_array(ndarray_obj_t *, ndarray_obj_t *);
 
 MP_DECLARE_CONST_FUN_OBJ_KW(ndarray_array_constructor_obj);
-#ifdef CIRCUITPY
-mp_obj_t ndarray_make_new(const mp_obj_type_t *type, size_t n_args, const mp_obj_t *args, mp_map_t *kw_args);
-#else
 mp_obj_t ndarray_make_new(const mp_obj_type_t *, size_t , size_t , const mp_obj_t *);
-#endif
 mp_obj_t ndarray_subscr(mp_obj_t , mp_obj_t , mp_obj_t );
 mp_obj_t ndarray_getiter(mp_obj_t , mp_obj_iter_buf_t *);
 bool ndarray_can_broadcast(ndarray_obj_t *, ndarray_obj_t *, uint8_t *, size_t *, int32_t *, int32_t *);


### PR DESCRIPTION
It's anticipated that circuitpython will no longer need this compat code after merging 1.17.
 * https://github.com/adafruit/circuitpython/issues/5463

We'll have to figure out how to sequence this change, since the CI here will be expected to fail on circuitpython main branch.