### PR TITLE
use ubuntu-latest for building micropython

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
         matrix:
             os:
-                - ubuntu-16.04
+                - ubuntu-latest
                 - macOS-latest
             dims: [1, 2, 3, 4]
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
This is what micropython uses now. 16.04 has been dropped by github/microsoft: https://github.com/actions/virtual-environments/issues/3287