### PR TITLE
Fix compare between (uint16|int16) vs float.

### DIFF
--- a/code/numpy/compare.c
+++ b/code/numpy/compare.c
@@ -89,7 +89,7 @@ static mp_obj_t compare_function(mp_obj_t x1, mp_obj_t x2, uint8_t op) {
         } else if(rhs->dtype == NDARRAY_INT16) {
             RUN_COMPARE_LOOP(NDARRAY_FLOAT, mp_float_t, uint16_t, int16_t, larray, lstrides, rarray, rstrides, ndim, shape, op);
         } else if(rhs->dtype == NDARRAY_FLOAT) {
-            RUN_COMPARE_LOOP(NDARRAY_FLOAT, mp_float_t, uint8_t, mp_float_t, larray, lstrides, rarray, rstrides, ndim, shape, op);
+            RUN_COMPARE_LOOP(NDARRAY_FLOAT, mp_float_t, uint16_t, mp_float_t, larray, lstrides, rarray, rstrides, ndim, shape, op);
         }
     } else if(lhs->dtype == NDARRAY_INT16) {
         if(rhs->dtype == NDARRAY_UINT8) {
@@ -101,7 +101,7 @@ static mp_obj_t compare_function(mp_obj_t x1, mp_obj_t x2, uint8_t op) {
         } else if(rhs->dtype == NDARRAY_INT16) {
             RUN_COMPARE_LOOP(NDARRAY_INT16, int16_t, int16_t, int16_t, larray, lstrides, rarray, rstrides, ndim, shape, op);
         } else if(rhs->dtype == NDARRAY_FLOAT) {
-            RUN_COMPARE_LOOP(NDARRAY_FLOAT, mp_float_t, uint16_t, mp_float_t, larray, lstrides, rarray, rstrides, ndim, shape, op);
+            RUN_COMPARE_LOOP(NDARRAY_FLOAT, mp_float_t, int16_t, mp_float_t, larray, lstrides, rarray, rstrides, ndim, shape, op);
         }
     } else if(lhs->dtype == NDARRAY_FLOAT) {
         if(rhs->dtype == NDARRAY_UINT8) {

--- a/code/ulab.c
+++ b/code/ulab.c
@@ -33,7 +33,7 @@
 #include "user/user.h"
 #include "utils/utils.h"
 
-#define ULAB_VERSION 3.3.4
+#define ULAB_VERSION 3.3.5
 #define xstr(s) str(s)
 #define str(s) #s
 #define ULAB_VERSION_STRING xstr(ULAB_VERSION) xstr(-) xstr(ULAB_MAX_DIMS) xstr(D)

--- a/docs/ulab-change-log.md
+++ b/docs/ulab-change-log.md
@@ -1,3 +1,9 @@
+Sun, 07 Nov 2021
+
+version 3.3.5
+
+    fix cast in numpy/compare.c:compare_function()
+
 Sat, 07 Aug 2021
 
 version 3.3.4


### PR DESCRIPTION
This PR fixes the following failure in ulab.numpy.maximum (and etc., observed in CircuitPython 7.0).

```
>>> np.maximum(np.ndarray([1000], dtype = np.uint16), 10.0)
array([232.0], dtype=float32)
>>> np.maximum(np.ndarray([-1000], dtype = np.int16), 10.0)
array([64536.0], dtype=float32)
```
