### PR TITLE
Created .readthedocs.yaml config file for latest versions

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,25 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "3.9"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/manual/source/conf.py
+
+# If using Sphinx, optionally build your docs in additional formats such as PDF
+# formats:
+#    - pdf
+
+# Optionally declare the Python requirements required to build your docs
+python:
+  install:
+    - requirements: requirements.txt

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # ulab
 
+[![Documentation Status](https://readthedocs.org/projects/micropython-ulab-robert/badge/?version=latest)](https://micropython-ulab-robert.readthedocs.io/en/latest/?badge=latest)
+
 `ulab` is a `numpy`-like array manipulation library for [micropython](http://micropython.org/) and [CircuitPython](https://circuitpython.org/).
 The module is written in C, defines compact containers for numerical data of one to four
 dimensions, and is fast. The library is a software-only standard `micropython` user module,


### PR DESCRIPTION
This should replace all settings from readthedocs.org. This is the recommended approach, as it's controlled by versions then.

This version is built at: https://micropython-ulab-robert.readthedocs.io/en/feature-rtd_config/

Relates to #443 