### PR TITLE
Adding branch release/v0.36 to suit version 0.36.1

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,26 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "3.9"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/manual/source/conf.py
+
+# If using Sphinx, optionally build your docs in additional formats such as PDF
+# formats:
+#    - pdf
+
+# Optionally declare the Python requirements required to build your docs
+#python:
+#  install:
+#    - requirements: requirements.txt
+# No requirements.txt for this version


### PR DESCRIPTION
I don't think I can create a new branch from a PR. This should be merged into a new branch `release/v0.36` and the tip of the branch should be tagged as `0.36.1`.

Example build can be found in https://micropython-ulab-robert.readthedocs.io/en/0.36.1 .

Relates to #443