### PR TITLE
Adding branch release/v0.54 to suit version 0.54.6

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,17 +13,17 @@ on:
     types: [rerequested]
 
 jobs:
-  test:
+  micropython:
     runs-on: ubuntu-16.04
     steps:
     - name: Dump GitHub context
       env:
         GITHUB_CONTEXT: ${{ toJson(github) }}
       run: echo "$GITHUB_CONTEXT"
-    - name: Set up Python 3.5
+    - name: Set up Python 3.8
       uses: actions/setup-python@v1
       with:
-        python-version: 3.5
+        python-version: 3.8
 
     - name: Versions
       run: |
@@ -60,3 +60,30 @@ jobs:
         done
       if: failure()
 
+  circuitpython:
+    runs-on: ubuntu-16.04
+    steps:
+    - name: Dump GitHub context
+      env:
+        GITHUB_CONTEXT: ${{ toJson(github) }}
+      run: echo "$GITHUB_CONTEXT"
+    - name: Set up Python 3.5
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.8
+
+    - name: Versions
+      run: |
+        gcc --version
+        python3 --version
+
+    - name: Checkout ulab
+      uses: actions/checkout@v1
+
+    - name: Install requirements
+      run: |
+        sudo apt install librsvg2-bin gettext
+        pip install "Sphinx<4" sphinx-rtd-theme recommonmark sphinx-autoapi sphinxcontrib-svg2pdfconverter astroid isort polib black
+
+    - name: Run build-cp.sh
+      run: ./build-cp.sh

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,26 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "3.9"
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/manual/source/conf.py
+
+# If using Sphinx, optionally build your docs in additional formats such as PDF
+# formats:
+#    - pdf
+
+# Optionally declare the Python requirements required to build your docs
+#python:
+#  install:
+#    - requirements: requirements.txt
+# No requirements.txt for this version

--- a/build-cp.sh
+++ b/build-cp.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+set -e
+nproc=$(python -c 'import multiprocessing; print(multiprocessing.cpu_count())')
+HERE="$(dirname -- "$(readlink -f -- "${0}")" )"
+[ -e circuitpython/py/py.mk ] || (git clone --depth 100 --branch 6.0.x https://github.com/adafruit/circuitpython && cd circuitpython && git submodule update --init)
+rm -rf circuitpython/extmod/ulab; ln -s "$HERE" circuitpython/extmod/ulab
+make -C circuitpython/mpy-cross -j$nproc
+make -C circuitpython/ports/unix -j$nproc deplibs
+make -C circuitpython/ports/unix -j$nproc
+
+if ! env MICROPY_MICROPYTHON=circuitpython/ports/unix/micropython circuitpython/tests/run-tests -d tests; then
+    for exp in *.exp; do
+        testbase=$(basename $exp .exp);
+        echo -e "\nFAILURE $testbase";
+        diff -u $testbase.exp $testbase.out;
+    done
+    exit 1
+fi
+
+(cd circuitpython && sphinx-build -E -W -b html . _build/html)

--- a/code/ndarray.c
+++ b/code/ndarray.c
@@ -167,7 +167,7 @@ mp_uint_t ndarray_print_edgeitems = NDARRAY_PRINT_EDGEITEMS;
 //|         ...
 //|
 //| _ArrayLike = Union[array, List[_float], Tuple[_float], range]
-//| """`ulab.array`, `List[float]`, `Tuple[float]` or `range`"""
+//| """`ulab.array`, ``List[float]``, ``Tuple[float]`` or `range`"""
 //|
 //| int8: _DType
 //| """Type code for signed integers in the range -128 .. 127 inclusive, like the 'b' typecode of `array.array`"""


### PR DESCRIPTION
Again, a new branch needs to be created first and this PR needs to be retargeted.

Example built is here: https://micropython-ulab-robert.readthedocs.io/en/0.54.6/

Relates to #443