### PR TITLE
fix ndarray_shape for arrays of zero length

### DIFF
--- a/code/ndarray.c
+++ b/code/ndarray.c
@@ -1479,12 +1479,13 @@ mp_obj_t ndarray_itemsize(mp_obj_t self_in) {
 #if NDARRAY_HAS_SHAPE
 mp_obj_t ndarray_shape(mp_obj_t self_in) {
     ndarray_obj_t *self = MP_OBJ_TO_PTR(self_in);
-    mp_obj_t *items = m_new(mp_obj_t, self->ndim);
-    for(uint8_t i=0; i < self->ndim; i++) {
-        items[self->ndim - i - 1] = mp_obj_new_int(self->shape[ULAB_MAX_DIMS - i - 1]);
+    uint8_t nitems = MAX(1, self->ndim);
+    mp_obj_t *items = m_new(mp_obj_t, nitems);
+    for(uint8_t i = 0; i < nitems; i++) {
+        items[nitems - i - 1] = mp_obj_new_int(self->shape[ULAB_MAX_DIMS - i - 1]);
     }
-    mp_obj_t tuple = mp_obj_new_tuple(self->ndim, items);
-    m_del(mp_obj_t, items, self->ndim);
+    mp_obj_t tuple = mp_obj_new_tuple(nitems, items);
+    m_del(mp_obj_t, items, nitems);
     return tuple;
 }
 #endif

--- a/code/ulab.c
+++ b/code/ulab.c
@@ -33,7 +33,7 @@
 #include "user/user.h"
 #include "utils/utils.h"
 
-#define ULAB_VERSION 3.3.5
+#define ULAB_VERSION 3.3.6
 #define xstr(s) str(s)
 #define str(s) #s
 #define ULAB_VERSION_STRING xstr(ULAB_VERSION) xstr(-) xstr(ULAB_MAX_DIMS) xstr(D)

--- a/docs/ulab-change-log.md
+++ b/docs/ulab-change-log.md
@@ -1,3 +1,9 @@
+Sat, 20 Nov 2021
+
+version 3.3.6
+
+    fix .shape for arrays of zero length (#454)
+
 Sun, 07 Nov 2021
 
 version 3.3.5


### PR DESCRIPTION
This PR should fix https://github.com/v923z/micropython-ulab/issues/454