### PR TITLE
Change how we alias the float and bool types for mypy

### DIFF
--- a/code/numpy/numerical.c
+++ b/code/numpy/numerical.c
@@ -48,11 +48,8 @@ enum NUMERICAL_FUNCTION_TYPE {
 //| _DType = int
 //| """`ulab.numpy.int8`, `ulab.numpy.uint8`, `ulab.numpy.int16`, `ulab.numpy.uint16`, `ulab.numpy.float` or `ulab.numpy.bool`"""
 //|
-//| _float = float
-//| """Type alias of the bulitin float"""
-//|
-//| _bool = bool
-//| """Type alias of the bulitin bool"""
+//| from builtins import float as _float
+//| from builtins import bool as _bool
 //|
 //| int8: _DType
 //| """Type code for signed integers in the range -128 .. 127 inclusive, like the 'b' typecode of `array.array`"""


### PR DESCRIPTION
mypy 0.920 started giving an error stating
```
ulab/numpy/__init__.pyi:51: error: Cannot assign multiple types to name "_float" without an explicit "Type[...]" annotation
ulab/numpy/__init__.pyi:54: error: Cannot assign multiple types to name "_bool" without an explicit "Type[...]" annotation
```

this quiets the error, and is also compatible with the previous version
(0.910).