### PR TITLE
json snippets

### DIFF
--- a/snippets/json_to_ndarray.py
+++ b/snippets/json_to_ndarray.py
@@ -58,7 +58,7 @@ def json_to_ndarray(json_string, b64=False):
 
     ndarray = np.frombuffer(data, dtype=dtype).reshape(tuple(obj['shape']))
 
-    if descriptor in (np.uint16, np.int16, np.float):
+    if dtype in (np.uint16, np.int16, np.float):
         if sys.byteorder != descriptor[1]:
             ndarray.byteswap()
 

--- a/snippets/json_to_ndarray.py
+++ b/snippets/json_to_ndarray.py
@@ -1,0 +1,70 @@
+import sys
+
+use_ulab = False
+
+try:
+    from ubinascii import a2b_base64 as b64decode
+    from ubinascii import unhexlify
+    import ujson as json
+    from ulab import numpy as np
+    use_ulab = True
+except:
+    from base64 import b64decode
+    import json
+    import numpy as np
+    from numpy.lib.format import descr_to_dtype
+
+def ulab_descr_to_dtype(descriptor):
+    descriptor = descriptor[1:]
+
+    if descriptor == 'u1':
+        return np.uint8
+    elif descriptor == 'i1':
+        return np.int8
+    if descriptor == 'u2':
+        return np.uint16
+    if descriptor == 'i2':
+        return np.int16
+    elif descriptor == 'f8':
+        if np.float != ord('d'):
+            raise TypeError('doubles are not supported')
+        else:
+            return np.float
+    elif descriptor == 'f16':
+        if np.float != ord('f'):
+            raise TypeError('')
+        else:
+            return np.float
+
+
+def json_to_ndarray(json_string, b64=False):
+    obj = json.loads(json_string)
+    print(obj)
+    if not isinstance(obj, dict):
+         raise TypeError('input argument must be a dictionary')
+    if set(obj.keys()) != {'__numpy__', 'dtype', 'shape'}:
+        raise ValueError('input must have the keys "__numpy__", "dtype", "shape"')
+
+    descriptor = obj['dtype']
+    if use_ulab:
+        dtype = ulab_descr_to_dtype(descriptor)
+    else:
+        dtype = descr_to_dtype(descriptor)
+
+    if not b64:
+        data = unhexlify(obj['__numpy__'])
+    else:
+        data = b64decode(obj['__numpy__'])
+
+    ndarray = np.frombuffer(data, dtype=dtype).reshape(tuple(obj['shape']))
+
+    if descriptor in (np.uint16, np.int16, np.float):
+        if sys.byteorder != descriptor[1]:
+            ndarray.byteswap()
+
+    return ndarray
+
+
+str = '{"dtype": "<f8", "__numpy__": "AAAAAAAAAAAAAAAAAADwPwAAAAAAAABAAAAAAAAACEAAAAAAAAAQQAAAAAAAABRAAAAAAAAAGEAAAAAAAAAcQAAAAAAAACBA\n", "shape": [3, 3]}'
+
+print(json_to_ndarray(str, b64=True))

--- a/snippets/ndarray_to_json.py
+++ b/snippets/ndarray_to_json.py
@@ -1,0 +1,60 @@
+import sys
+
+use_ulab = False
+
+try:
+    from ubinascii import a2b_base64 as b64encode
+    from ubinascii import hexlify
+    import ujson as json
+    from ulab import numpy as np
+    use_ulab = True
+except:
+    from base64 import b64encode
+    import json
+    import numpy as np
+    from numpy.lib.format import dtype_to_descr
+
+def ulab_dtype_to_descr(dtype):
+    desc = '<'
+    if sys.byteorder == 'little':
+        desc = '>'
+
+    if dtype == ord('B'):
+        desc = desc + 'u1'
+    elif dtype == ord('b'):
+        desc = desc + 'i1'
+    elif dtype == ord('H'):
+        desc = desc + 'u2'
+    elif dtype == ord('h'):
+        desc = desc + 'i2'
+    elif dtype == ord('d'):
+        desc = desc + 'f8'
+    elif dtype == ord('f'):
+        desc = desc + 'f4'
+    elif dtype == ord('c'):
+        desc = desc + 'c16'
+        if np.array([1], dtype=np.float).itemsize == 4:
+            desc = desc + 'c8'
+
+    return desc
+
+def ndarray_to_json(obj, b64=False):
+    if not isinstance(obj, np.ndarray):
+         raise TypeError('input argument must be an ndarray')
+
+    if use_ulab:
+        dtype_desciptor = ulab_dtype_to_descr(obj.dtype)
+    else:
+        dtype_desciptor = dtype_to_descr(obj.dtype)
+
+    if not b64:
+        data = hexlify(obj.tobytes())
+
+    return json.dumps({'__numpy__': data, 'dtype': dtype_desciptor, 'shape': obj.shape})
+
+
+dtypes = (np.uint8, np.int8, np.uint16, np.int16, np.float)
+
+for dtype in dtypes:
+    ndarray = np.array([1, 2, 3], dtype=dtype)
+    print(ndarray_to_json(ndarray))

--- a/snippets/ndarray_to_json.py
+++ b/snippets/ndarray_to_json.py
@@ -20,9 +20,9 @@ def ulab_dtype_to_descr(dtype):
         desc = '<'
 
     if dtype == ord('B'):
-        desc = desc + 'u1'
+        desc = '|u1'
     elif dtype == ord('b'):
-        desc = desc + 'i1'
+        desc = '|i1'
     elif dtype == ord('H'):
         desc = desc + 'u2'
     elif dtype == ord('h'):
@@ -58,6 +58,6 @@ def ndarray_to_json(obj, b64=False):
 dtypes = (np.uint8, np.int8, np.uint16, np.int16, np.float)
 
 for dtype in dtypes:
-    ndarray = np.array([1, 2, 3], dtype=dtype)
+    ndarray = np.array(range(9), dtype=dtype).reshape((3,3))
     print(ndarray_to_json(ndarray))
     print(ndarray_to_json(ndarray, b64=True))

--- a/snippets/ndarray_to_json.py
+++ b/snippets/ndarray_to_json.py
@@ -3,7 +3,7 @@ import sys
 use_ulab = False
 
 try:
-    from ubinascii import a2b_base64 as b64encode
+    from ubinascii import b2a_base64 as b64encode
     from ubinascii import hexlify
     import ujson as json
     from ulab import numpy as np
@@ -49,6 +49,8 @@ def ndarray_to_json(obj, b64=False):
 
     if not b64:
         data = hexlify(obj.tobytes())
+    else:
+        data = b64encode(obj.tobytes())
 
     return json.dumps({'__numpy__': data, 'dtype': dtype_desciptor, 'shape': obj.shape})
 
@@ -58,3 +60,4 @@ dtypes = (np.uint8, np.int8, np.uint16, np.int16, np.float)
 for dtype in dtypes:
     ndarray = np.array([1, 2, 3], dtype=dtype)
     print(ndarray_to_json(ndarray))
+    print(ndarray_to_json(ndarray, b64=True))

--- a/snippets/ndarray_to_json.py
+++ b/snippets/ndarray_to_json.py
@@ -15,9 +15,9 @@ except:
     from numpy.lib.format import dtype_to_descr
 
 def ulab_dtype_to_descr(dtype):
-    desc = '<'
+    desc = '>'
     if sys.byteorder == 'little':
-        desc = '>'
+        desc = '<'
 
     if dtype == ord('B'):
         desc = desc + 'u1'


### PR DESCRIPTION
This PR adds two snippets, with which one can convert ndarrays to serialised json string, and vice versa. This should address the issue mentioned in https://github.com/v923z/micropython-ulab/issues/468#issuecomment-1012372905 and thereafter, and should also close https://github.com/v923z/micropython-ulab/issues/476.