### PR TITLE
add ULAB_HASH

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -45,7 +45,7 @@ HERE="$(dirname -- "$(readlinkf_posix -- "${0}")" )"
 dims=${1-2}
 make -C micropython/mpy-cross -j${NPROC}
 make -C micropython/ports/unix -j${NPROC} axtls
-make -C micropython/ports/unix -j${NPROC} USER_C_MODULES="${HERE}" DEBUG=1 STRIP=: MICROPY_PY_FFI=0 MICROPY_PY_BTREE=0 CFLAGS_EXTRA=-DULAB_MAX_DIMS=$dims CFLAGS_EXTRA=-DULAB_HASH=$GIT_HASH BUILD=build-$dims PROG=micropython-$dims
+make -C micropython/ports/unix -j${NPROC} USER_C_MODULES="${HERE}" DEBUG=1 STRIP=: MICROPY_PY_FFI=0 MICROPY_PY_BTREE=0 CFLAGS_EXTRA=-DULAB_MAX_DIMS=$dims CFLAGS_EXTRA+=-DULAB_HASH=$GIT_HASH BUILD=build-$dims PROG=micropython-$dims
 
 bash test-common.sh "${dims}" "micropython/ports/unix/micropython-$dims"
 

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
+
+GIT_HASH=`git describe --abbrev=8 --always`
+
 # POSIX compliant version
 readlinkf_posix() {
   [ "${1:-}" ] || return 1
@@ -42,7 +45,7 @@ HERE="$(dirname -- "$(readlinkf_posix -- "${0}")" )"
 dims=${1-2}
 make -C micropython/mpy-cross -j${NPROC}
 make -C micropython/ports/unix -j${NPROC} axtls
-make -C micropython/ports/unix -j${NPROC} USER_C_MODULES="${HERE}" DEBUG=1 STRIP=: MICROPY_PY_FFI=0 MICROPY_PY_BTREE=0 CFLAGS_EXTRA=-DULAB_MAX_DIMS=$dims BUILD=build-$dims PROG=micropython-$dims
+make -C micropython/ports/unix -j${NPROC} USER_C_MODULES="${HERE}" DEBUG=1 STRIP=: MICROPY_PY_FFI=0 MICROPY_PY_BTREE=0 CFLAGS_EXTRA=-DULAB_MAX_DIMS=$dims CFLAGS_EXTRA=-DULAB_HASH=$GIT_HASH BUILD=build-$dims PROG=micropython-$dims
 
 bash test-common.sh "${dims}" "micropython/ports/unix/micropython-$dims"
 

--- a/code/ulab.c
+++ b/code/ulab.c
@@ -33,7 +33,7 @@
 #include "user/user.h"
 #include "utils/utils.h"
 
-#define ULAB_VERSION 5.0.0
+#define ULAB_VERSION 5.0.1
 #define xstr(s) str(s)
 #define str(s) #s
 
@@ -45,6 +45,9 @@
 
 STATIC MP_DEFINE_STR_OBJ(ulab_version_obj, ULAB_VERSION_STRING);
 
+#ifdef ULAB_HASH
+STATIC MP_DEFINE_STR_OBJ(ulab_sha_obj, xstr(ULAB_HASH));
+#endif
 
 STATIC const mp_rom_map_elem_t ulab_ndarray_locals_dict_table[] = {
     #if ULAB_MAX_DIMS > 1
@@ -149,6 +152,9 @@ const mp_obj_type_t ndarray_flatiter_type = {
 STATIC const mp_map_elem_t ulab_globals_table[] = {
     { MP_OBJ_NEW_QSTR(MP_QSTR___name__), MP_OBJ_NEW_QSTR(MP_QSTR_ulab) },
     { MP_ROM_QSTR(MP_QSTR___version__), MP_ROM_PTR(&ulab_version_obj) },
+    #ifdef ULAB_HASH
+    { MP_ROM_QSTR(MP_QSTR___sha__), MP_ROM_PTR(&ulab_sha_obj) },
+    #endif
     #if ULAB_HAS_DTYPE_OBJECT
         { MP_OBJ_NEW_QSTR(MP_QSTR_dtype), (mp_obj_t)&ulab_dtype_type },
     #else

--- a/docs/ulab-change-log.md
+++ b/docs/ulab-change-log.md
@@ -1,3 +1,9 @@
+Thu, 3 Feb 2022
+
+version 5.0.1
+
+    add optional ULAB_HASH string
+
 Tue, 1 Feb 2022
 
 version 5.0.0


### PR DESCRIPTION
This PR only adds the optional ULAB_HASH compile-time constant that, when defined, can be retrieved as `ulab.__sha__`.