### PR TITLE
Properly register submodules of ulab

### DIFF
--- a/build-cp.sh
+++ b/build-cp.sh
@@ -35,7 +35,7 @@ readlinkf_posix() {
   done
   return 1
 }
-NPROC=$(python -c 'import multiprocessing; print(multiprocessing.cpu_count())')
+NPROC=$(python3 -c 'import multiprocessing; print(multiprocessing.cpu_count())')
 HERE="$(dirname -- "$(readlinkf_posix -- "${0}")" )"
 [ -e circuitpython/py/py.mk ] || (git clone --no-recurse-submodules --depth 100 --branch main https://github.com/adafruit/circuitpython && cd circuitpython && git submodule update --init lib/uzlib tools)
 rm -rf circuitpython/extmod/ulab; ln -s "$HERE" circuitpython/extmod/ulab

--- a/code/numpy/fft/fft.c
+++ b/code/numpy/fft/fft.c
@@ -99,3 +99,4 @@ mp_obj_module_t ulab_fft_module = {
     .base = { &mp_type_module },
     .globals = (mp_obj_dict_t*)&mp_module_ulab_fft_globals,
 };
+MP_REGISTER_MODULE(MP_QSTR_ulab_dot_fft, ulab_fft_module, MODULE_ULAB_ENABLED);

--- a/code/numpy/fft/fft.c
+++ b/code/numpy/fft/fft.c
@@ -95,8 +95,8 @@ STATIC const mp_rom_map_elem_t ulab_fft_globals_table[] = {
 
 STATIC MP_DEFINE_CONST_DICT(mp_module_ulab_fft_globals, ulab_fft_globals_table);
 
-mp_obj_module_t ulab_fft_module = {
+const mp_obj_module_t ulab_fft_module = {
     .base = { &mp_type_module },
     .globals = (mp_obj_dict_t*)&mp_module_ulab_fft_globals,
 };
-MP_REGISTER_MODULE(MP_QSTR_ulab_dot_fft, ulab_fft_module, MODULE_ULAB_ENABLED);
+MP_REGISTER_MODULE(MP_QSTR_ulab_dot_fft, ulab_fft_module, MODULE_ULAB_ENABLED && CIRCUITPY_ULAB);

--- a/code/numpy/fft/fft.h
+++ b/code/numpy/fft/fft.h
@@ -17,7 +17,7 @@
 #include "../../ndarray.h"
 #include "fft_tools.h"
 
-extern mp_obj_module_t ulab_fft_module;
+extern const mp_obj_module_t ulab_fft_module;
 
 #if ULAB_SUPPORTS_COMPLEX & ULAB_FFT_IS_NUMPY_COMPATIBLE
 MP_DECLARE_CONST_FUN_OBJ_3(fft_fft_obj);

--- a/code/numpy/linalg/linalg.c
+++ b/code/numpy/linalg/linalg.c
@@ -536,5 +536,6 @@ mp_obj_module_t ulab_linalg_module = {
     .base = { &mp_type_module },
     .globals = (mp_obj_dict_t*)&mp_module_ulab_linalg_globals,
 };
+MP_REGISTER_MODULE(MP_QSTR_ulab_dot_linalg, ulab_linalg_module, MODULE_ULAB_ENABLED);
 
 #endif

--- a/code/numpy/linalg/linalg.c
+++ b/code/numpy/linalg/linalg.c
@@ -532,10 +532,10 @@ STATIC const mp_rom_map_elem_t ulab_linalg_globals_table[] = {
 
 STATIC MP_DEFINE_CONST_DICT(mp_module_ulab_linalg_globals, ulab_linalg_globals_table);
 
-mp_obj_module_t ulab_linalg_module = {
+const mp_obj_module_t ulab_linalg_module = {
     .base = { &mp_type_module },
     .globals = (mp_obj_dict_t*)&mp_module_ulab_linalg_globals,
 };
-MP_REGISTER_MODULE(MP_QSTR_ulab_dot_linalg, ulab_linalg_module, MODULE_ULAB_ENABLED);
+MP_REGISTER_MODULE(MP_QSTR_ulab_dot_linalg, ulab_linalg_module, MODULE_ULAB_ENABLED && CIRCUITPY_ULAB);
 
 #endif

--- a/code/numpy/linalg/linalg.h
+++ b/code/numpy/linalg/linalg.h
@@ -16,7 +16,7 @@
 #include "../../ndarray.h"
 #include "linalg_tools.h"
 
-extern mp_obj_module_t ulab_linalg_module;
+extern const mp_obj_module_t ulab_linalg_module;
 
 MP_DECLARE_CONST_FUN_OBJ_1(linalg_cholesky_obj);
 MP_DECLARE_CONST_FUN_OBJ_1(linalg_det_obj);

--- a/code/numpy/numpy.c
+++ b/code/numpy/numpy.c
@@ -379,3 +379,5 @@ mp_obj_module_t ulab_numpy_module = {
     .base = { &mp_type_module },
     .globals = (mp_obj_dict_t*)&mp_module_ulab_numpy_globals,
 };
+
+MP_REGISTER_MODULE(MP_QSTR_ulab_dot_numpy, ulab_numpy_module, MODULE_ULAB_ENABLED);

--- a/code/numpy/numpy.c
+++ b/code/numpy/numpy.c
@@ -375,9 +375,9 @@ static const mp_rom_map_elem_t ulab_numpy_globals_table[] = {
 
 static MP_DEFINE_CONST_DICT(mp_module_ulab_numpy_globals, ulab_numpy_globals_table);
 
-mp_obj_module_t ulab_numpy_module = {
+const mp_obj_module_t ulab_numpy_module = {
     .base = { &mp_type_module },
     .globals = (mp_obj_dict_t*)&mp_module_ulab_numpy_globals,
 };
 
-MP_REGISTER_MODULE(MP_QSTR_ulab_dot_numpy, ulab_numpy_module, MODULE_ULAB_ENABLED);
+MP_REGISTER_MODULE(MP_QSTR_ulab_dot_numpy, ulab_numpy_module, MODULE_ULAB_ENABLED && CIRCUITPY_ULAB);

--- a/code/numpy/numpy.h
+++ b/code/numpy/numpy.h
@@ -16,6 +16,6 @@
 #include "../ulab.h"
 #include "../ndarray.h"
 
-extern mp_obj_module_t ulab_numpy_module;
+extern const mp_obj_module_t ulab_numpy_module;
 
 #endif /* _NUMPY_ */

--- a/code/scipy/linalg/linalg.c
+++ b/code/scipy/linalg/linalg.c
@@ -275,5 +275,6 @@ mp_obj_module_t ulab_scipy_linalg_module = {
     .base = { &mp_type_module },
     .globals = (mp_obj_dict_t*)&mp_module_ulab_scipy_linalg_globals,
 };
+MP_REGISTER_MODULE(MP_QSTR_ulab_dot_scipy_dot_linalg, ulab_scipy_linalg_module, MODULE_ULAB_ENABLED);
 
 #endif

--- a/code/scipy/linalg/linalg.c
+++ b/code/scipy/linalg/linalg.c
@@ -271,10 +271,10 @@ static const mp_rom_map_elem_t ulab_scipy_linalg_globals_table[] = {
 
 static MP_DEFINE_CONST_DICT(mp_module_ulab_scipy_linalg_globals, ulab_scipy_linalg_globals_table);
 
-mp_obj_module_t ulab_scipy_linalg_module = {
+const mp_obj_module_t ulab_scipy_linalg_module = {
     .base = { &mp_type_module },
     .globals = (mp_obj_dict_t*)&mp_module_ulab_scipy_linalg_globals,
 };
-MP_REGISTER_MODULE(MP_QSTR_ulab_dot_scipy_dot_linalg, ulab_scipy_linalg_module, MODULE_ULAB_ENABLED);
+MP_REGISTER_MODULE(MP_QSTR_ulab_dot_scipy_dot_linalg, ulab_scipy_linalg_module, MODULE_ULAB_ENABLED && CIRCUITPY_ULAB);
 
 #endif

--- a/code/scipy/linalg/linalg.h
+++ b/code/scipy/linalg/linalg.h
@@ -13,7 +13,7 @@
 #ifndef _SCIPY_LINALG_
 #define _SCIPY_LINALG_
 
-extern mp_obj_module_t ulab_scipy_linalg_module;
+extern const mp_obj_module_t ulab_scipy_linalg_module;
 
 MP_DECLARE_CONST_FUN_OBJ_KW(linalg_solve_triangular_obj);
 MP_DECLARE_CONST_FUN_OBJ_2(linalg_cho_solve_obj);

--- a/code/scipy/optimize/optimize.c
+++ b/code/scipy/optimize/optimize.c
@@ -412,3 +412,4 @@ mp_obj_module_t ulab_scipy_optimize_module = {
     .base = { &mp_type_module },
     .globals = (mp_obj_dict_t*)&mp_module_ulab_scipy_optimize_globals,
 };
+MP_REGISTER_MODULE(MP_QSTR_ulab_dot_scipy_dot_optimize, ulab_scipy_optimize_module, MODULE_ULAB_ENABLED);

--- a/code/scipy/optimize/optimize.c
+++ b/code/scipy/optimize/optimize.c
@@ -408,8 +408,8 @@ static const mp_rom_map_elem_t ulab_scipy_optimize_globals_table[] = {
 
 static MP_DEFINE_CONST_DICT(mp_module_ulab_scipy_optimize_globals, ulab_scipy_optimize_globals_table);
 
-mp_obj_module_t ulab_scipy_optimize_module = {
+const mp_obj_module_t ulab_scipy_optimize_module = {
     .base = { &mp_type_module },
     .globals = (mp_obj_dict_t*)&mp_module_ulab_scipy_optimize_globals,
 };
-MP_REGISTER_MODULE(MP_QSTR_ulab_dot_scipy_dot_optimize, ulab_scipy_optimize_module, MODULE_ULAB_ENABLED);
+MP_REGISTER_MODULE(MP_QSTR_ulab_dot_scipy_dot_optimize, ulab_scipy_optimize_module, MODULE_ULAB_ENABLED && CIRCUITPY_ULAB);

--- a/code/scipy/optimize/optimize.h
+++ b/code/scipy/optimize/optimize.h
@@ -31,7 +31,7 @@
 #define     OPTIMIZE_GAMMA        MICROPY_FLOAT_CONST(0.5)
 #define     OPTIMIZE_DELTA        MICROPY_FLOAT_CONST(0.5)
 
-extern mp_obj_module_t ulab_scipy_optimize_module;
+extern const mp_obj_module_t ulab_scipy_optimize_module;
 
 MP_DECLARE_CONST_FUN_OBJ_KW(optimize_bisect_obj);
 MP_DECLARE_CONST_FUN_OBJ_KW(optimize_curve_fit_obj);

--- a/code/scipy/scipy.c
+++ b/code/scipy/scipy.c
@@ -48,4 +48,5 @@ mp_obj_module_t ulab_scipy_module = {
     .base = { &mp_type_module },
     .globals = (mp_obj_dict_t*)&mp_module_ulab_scipy_globals,
 };
+MP_REGISTER_MODULE(MP_QSTR_ulab_dot_scipy, ulab_scipy_module, MODULE_ULAB_ENABLED);
 #endif

--- a/code/scipy/scipy.c
+++ b/code/scipy/scipy.c
@@ -44,9 +44,9 @@ static const mp_rom_map_elem_t ulab_scipy_globals_table[] = {
 
 static MP_DEFINE_CONST_DICT(mp_module_ulab_scipy_globals, ulab_scipy_globals_table);
 
-mp_obj_module_t ulab_scipy_module = {
+const mp_obj_module_t ulab_scipy_module = {
     .base = { &mp_type_module },
     .globals = (mp_obj_dict_t*)&mp_module_ulab_scipy_globals,
 };
-MP_REGISTER_MODULE(MP_QSTR_ulab_dot_scipy, ulab_scipy_module, MODULE_ULAB_ENABLED);
+MP_REGISTER_MODULE(MP_QSTR_ulab_dot_scipy, ulab_scipy_module, MODULE_ULAB_ENABLED && CIRCUITPY_ULAB);
 #endif

--- a/code/scipy/scipy.h
+++ b/code/scipy/scipy.h
@@ -16,6 +16,6 @@
 #include "../ulab.h"
 #include "../ndarray.h"
 
-extern mp_obj_module_t ulab_scipy_module;
+extern const mp_obj_module_t ulab_scipy_module;
 
 #endif /* _SCIPY_ */

--- a/code/scipy/signal/signal.c
+++ b/code/scipy/signal/signal.c
@@ -165,8 +165,8 @@ static const mp_rom_map_elem_t ulab_scipy_signal_globals_table[] = {
 
 static MP_DEFINE_CONST_DICT(mp_module_ulab_scipy_signal_globals, ulab_scipy_signal_globals_table);
 
-mp_obj_module_t ulab_scipy_signal_module = {
+const mp_obj_module_t ulab_scipy_signal_module = {
     .base = { &mp_type_module },
     .globals = (mp_obj_dict_t*)&mp_module_ulab_scipy_signal_globals,
 };
-MP_REGISTER_MODULE(MP_QSTR_ulab_dot_scipy_dot_signal, ulab_scipy_signal_module, MODULE_ULAB_ENABLED);
+MP_REGISTER_MODULE(MP_QSTR_ulab_dot_scipy_dot_signal, ulab_scipy_signal_module, MODULE_ULAB_ENABLED && CIRCUITPY_ULAB);

--- a/code/scipy/signal/signal.c
+++ b/code/scipy/signal/signal.c
@@ -169,3 +169,4 @@ mp_obj_module_t ulab_scipy_signal_module = {
     .base = { &mp_type_module },
     .globals = (mp_obj_dict_t*)&mp_module_ulab_scipy_signal_globals,
 };
+MP_REGISTER_MODULE(MP_QSTR_ulab_dot_scipy_dot_signal, ulab_scipy_signal_module, MODULE_ULAB_ENABLED);

--- a/code/scipy/signal/signal.h
+++ b/code/scipy/signal/signal.h
@@ -16,7 +16,7 @@
 #include "../../ulab.h"
 #include "../../ndarray.h"
 
-extern mp_obj_module_t ulab_scipy_signal_module;
+extern const mp_obj_module_t ulab_scipy_signal_module;
 
 MP_DECLARE_CONST_FUN_OBJ_VAR_BETWEEN(signal_spectrogram_obj);
 MP_DECLARE_CONST_FUN_OBJ_KW(signal_sosfilt_obj);

--- a/code/scipy/special/special.c
+++ b/code/scipy/special/special.c
@@ -36,8 +36,8 @@ static const mp_rom_map_elem_t ulab_scipy_special_globals_table[] = {
 
 static MP_DEFINE_CONST_DICT(mp_module_ulab_scipy_special_globals, ulab_scipy_special_globals_table);
 
-mp_obj_module_t ulab_scipy_special_module = {
+const mp_obj_module_t ulab_scipy_special_module = {
     .base = { &mp_type_module },
     .globals = (mp_obj_dict_t*)&mp_module_ulab_scipy_special_globals,
 };
-MP_REGISTER_MODULE(MP_QSTR_ulab_dot_scipy_dot_special, ulab_scipy_special_module, MODULE_ULAB_ENABLED);
+MP_REGISTER_MODULE(MP_QSTR_ulab_dot_scipy_dot_special, ulab_scipy_special_module, MODULE_ULAB_ENABLED && CIRCUITPY_ULAB);

--- a/code/scipy/special/special.c
+++ b/code/scipy/special/special.c
@@ -40,3 +40,4 @@ mp_obj_module_t ulab_scipy_special_module = {
     .base = { &mp_type_module },
     .globals = (mp_obj_dict_t*)&mp_module_ulab_scipy_special_globals,
 };
+MP_REGISTER_MODULE(MP_QSTR_ulab_dot_scipy_dot_special, ulab_scipy_special_module, MODULE_ULAB_ENABLED);

--- a/code/scipy/special/special.h
+++ b/code/scipy/special/special.h
@@ -16,6 +16,6 @@
 #include "../../ulab.h"
 #include "../../ndarray.h"
 
-extern mp_obj_module_t ulab_scipy_special_module;
+extern const mp_obj_module_t ulab_scipy_special_module;
 
 #endif /* _SCIPY_SPECIAL_ */

--- a/code/ulab.c
+++ b/code/ulab.c
@@ -156,15 +156,15 @@ STATIC const mp_map_elem_t ulab_globals_table[] = {
         { MP_OBJ_NEW_QSTR(MP_QSTR_dtype), (mp_obj_t)&ndarray_dtype_obj },
         #endif /* NDARRAY_HAS_DTYPE */
     #endif /* ULAB_HAS_DTYPE_OBJECT */
-        { MP_ROM_QSTR(MP_QSTR_numpy), MP_ROM_PTR(&ulab_numpy_module) },
+        { MP_ROM_QSTR(MP_QSTR_numpy), MP_ROM_PTR((mp_obj_t)&ulab_numpy_module) },
     #if ULAB_HAS_SCIPY
-        { MP_ROM_QSTR(MP_QSTR_scipy), MP_ROM_PTR(&ulab_scipy_module) },
+        { MP_ROM_QSTR(MP_QSTR_scipy), MP_ROM_PTR((mp_obj_t)&ulab_scipy_module) },
     #endif
     #if ULAB_HAS_USER_MODULE
-        { MP_ROM_QSTR(MP_QSTR_user), MP_ROM_PTR(&ulab_user_module) },
+        { MP_ROM_QSTR(MP_QSTR_user), MP_ROM_PTR((mp_obj_t)&ulab_user_module) },
     #endif
     #if ULAB_HAS_UTILS_MODULE
-        { MP_ROM_QSTR(MP_QSTR_utils), MP_ROM_PTR(&ulab_utils_module) },
+        { MP_ROM_QSTR(MP_QSTR_utils), MP_ROM_PTR((mp_obj_t)&ulab_utils_module) },
     #endif
 };
 

--- a/code/user/user.c
+++ b/code/user/user.c
@@ -87,10 +87,10 @@ static const mp_rom_map_elem_t ulab_user_globals_table[] = {
 
 static MP_DEFINE_CONST_DICT(mp_module_ulab_user_globals, ulab_user_globals_table);
 
-mp_obj_module_t ulab_user_module = {
+const mp_obj_module_t ulab_user_module = {
     .base = { &mp_type_module },
     .globals = (mp_obj_dict_t*)&mp_module_ulab_user_globals,
 };
-MP_REGISTER_MODULE(MP_QSTR_ulab_dot_user, ulab_user_module, ULAB_HAS_USER_MODULE);
+MP_REGISTER_MODULE(MP_QSTR_ulab_dot_user, ulab_user_module, ULAB_HAS_USER_MODULE && CIRCUITPY_ULAB);
 
 #endif

--- a/code/user/user.c
+++ b/code/user/user.c
@@ -91,5 +91,6 @@ mp_obj_module_t ulab_user_module = {
     .base = { &mp_type_module },
     .globals = (mp_obj_dict_t*)&mp_module_ulab_user_globals,
 };
+MP_REGISTER_MODULE(MP_QSTR_ulab_dot_user, ulab_user_module, ULAB_HAS_USER_MODULE);
 
 #endif

--- a/code/user/user.h
+++ b/code/user/user.h
@@ -15,6 +15,6 @@
 #include "../ulab.h"
 #include "../ndarray.h"
 
-extern mp_obj_module_t ulab_user_module;
+extern const mp_obj_module_t ulab_user_module;
 
 #endif

--- a/code/utils/utils.c
+++ b/code/utils/utils.c
@@ -207,10 +207,10 @@ static const mp_rom_map_elem_t ulab_utils_globals_table[] = {
 
 static MP_DEFINE_CONST_DICT(mp_module_ulab_utils_globals, ulab_utils_globals_table);
 
-mp_obj_module_t ulab_utils_module = {
+const mp_obj_module_t ulab_utils_module = {
     .base = { &mp_type_module },
     .globals = (mp_obj_dict_t*)&mp_module_ulab_utils_globals,
 };
-MP_REGISTER_MODULE(MP_QSTR_ulab_dot_utils, ulab_utils_module, MODULE_ULAB_ENABLED);
+MP_REGISTER_MODULE(MP_QSTR_ulab_dot_utils, ulab_utils_module, MODULE_ULAB_ENABLED && CIRCUITPY_ULAB);
 
 #endif

--- a/code/utils/utils.c
+++ b/code/utils/utils.c
@@ -211,5 +211,6 @@ mp_obj_module_t ulab_utils_module = {
     .base = { &mp_type_module },
     .globals = (mp_obj_dict_t*)&mp_module_ulab_utils_globals,
 };
+MP_REGISTER_MODULE(MP_QSTR_ulab_dot_utils, ulab_utils_module, MODULE_ULAB_ENABLED);
 
 #endif

--- a/code/utils/utils.h
+++ b/code/utils/utils.h
@@ -14,6 +14,6 @@
 #include "../ulab.h"
 #include "../ndarray.h"
 
-extern mp_obj_module_t ulab_utils_module;
+extern const mp_obj_module_t ulab_utils_module;
 
 #endif


### PR DESCRIPTION
This is related to
 * https://github.com/adafruit/circuitpython/issues/6066

in which, after the merge of 1.18 into CircuitPython, we lost the ability to import submodules of built-in modules.

While reconstructing the changes we had made locally to enable this, I discovered that there was an easier way: simply register the dotted module names via MP_REGISTER_MODULE.

In CircuitPython, we'd like this as a hotfix for ulab 4.0.0, so instead of just merging this to master we may need to create a branch for it (or re-use "legacy", which was previously at 1.7.x I think also for CircuitPython)

This is not absoutely urgent, it does not affect the upcoming 7.2.0 release of CircuitPython, just our 'main' development branch where we merged MicroPython 1.18.