### PR TITLE
Fix error message for maximum number of dimensions

### DIFF
--- a/code/ndarray.c
+++ b/code/ndarray.c
@@ -2077,7 +2077,7 @@ mp_obj_t ndarray_reshape_core(mp_obj_t oin, mp_obj_t _shape, bool inplace) {
 
     mp_obj_tuple_t *shape = MP_OBJ_TO_PTR(_shape);
     if(shape->len > ULAB_MAX_DIMS) {
-        mp_raise_ValueError(translate("maximum number of dimensions is 4"));
+        mp_raise_ValueError(translate("maximum number of dimensions is " MP_STRINGIFY(ULAB_MAX_DIMS)));
     }
     size_t *new_shape = m_new0(size_t, ULAB_MAX_DIMS);
 


### PR DESCRIPTION
Prior to this change, if you built ulab with the default 2 dimensions and ran code that needed more than 2 (eg `tests/4d/complex/imag_real.py`) it would error out with the confusing message "ValueError: maximum number of dimensions is 4".