### PR TITLE
Fix several build errors in CircuitPython

### DIFF
--- a/build-cp.sh
+++ b/build-cp.sh
@@ -35,7 +35,7 @@ readlinkf_posix() {
   done
   return 1
 }
-NPROC=$(python -c 'import multiprocessing; print(multiprocessing.cpu_count())')
+NPROC=$(python3 -c 'import multiprocessing; print(multiprocessing.cpu_count())')
 HERE="$(dirname -- "$(readlinkf_posix -- "${0}")" )"
 [ -e circuitpython/py/py.mk ] || (git clone --branch main https://github.com/adafruit/circuitpython && cd circuitpython && make fetch-submodules && git submodule update --init lib/uzlib tools)
 rm -rf circuitpython/extmod/ulab; ln -s "$HERE" circuitpython/extmod/ulab

--- a/build.sh
+++ b/build.sh
@@ -48,11 +48,12 @@ make -C micropython/mpy-cross -j${NPROC}
 make -C micropython/ports/unix -j${NPROC} axtls
 make -C micropython/ports/unix -j${NPROC} USER_C_MODULES="${HERE}" DEBUG=1 STRIP=: MICROPY_PY_FFI=0 MICROPY_PY_BTREE=0 CFLAGS_EXTRA=-DULAB_MAX_DIMS=$dims CFLAGS_EXTRA+=-DULAB_HASH=$GIT_HASH BUILD=build-$dims PROG=micropython-$dims
 
+bash test-common.sh "${dims}" "micropython/ports/unix/micropython-$dims"
+
 # The unix nanbox variant builds as a 32-bit executable and requires gcc-multilib.
 # macOS doesn't support i386 builds so only build on linux.
 if [ $PLATFORM = linux ]; then
     make -C micropython/ports/unix -j${NPROC} VARIANT=nanbox USER_C_MODULES="${HERE}" DEBUG=1 STRIP=: MICROPY_PY_FFI=0 MICROPY_PY_BTREE=0 CFLAGS_EXTRA=-DULAB_MAX_DIMS=$dims CFLAGS_EXTRA+=-DULAB_HASH=$GIT_HASH BUILD=build-nanbox-$dims PROG=micropython-nanbox-$dims
+    bash test-common.sh "${dims}" "micropython/ports/unix/micropython-$dims"
 fi
-
-bash test-common.sh "${dims}" "micropython/ports/unix/micropython-$dims"
 

--- a/code/numpy/fft/fft.c
+++ b/code/numpy/fft/fft.c
@@ -96,7 +96,8 @@ STATIC const mp_rom_map_elem_t ulab_fft_globals_table[] = {
 
 STATIC MP_DEFINE_CONST_DICT(mp_module_ulab_fft_globals, ulab_fft_globals_table);
 
-mp_obj_module_t ulab_fft_module = {
+const mp_obj_module_t ulab_fft_module = {
     .base = { &mp_type_module },
     .globals = (mp_obj_dict_t*)&mp_module_ulab_fft_globals,
 };
+MP_REGISTER_MODULE(MP_QSTR_ulab_dot_fft, ulab_fft_module, MODULE_ULAB_ENABLED && CIRCUITPY_ULAB);

--- a/code/numpy/fft/fft.c
+++ b/code/numpy/fft/fft.c
@@ -100,4 +100,10 @@ const mp_obj_module_t ulab_fft_module = {
     .base = { &mp_type_module },
     .globals = (mp_obj_dict_t*)&mp_module_ulab_fft_globals,
 };
-MP_REGISTER_MODULE(MP_QSTR_ulab_dot_fft, ulab_fft_module, MODULE_ULAB_ENABLED && CIRCUITPY_ULAB);
+#if CIRCUITPY_ULAB
+#if !defined(MICROPY_VERSION) || MICROPY_VERSION <= 70144
+MP_REGISTER_MODULE(MP_QSTR_ulab_dot_numpy_dot_fft, ulab_fft_module, MODULE_ULAB_ENABLED);
+#else
+MP_REGISTER_MODULE(MP_QSTR_ulab_dot_numpy_dot_fft, ulab_fft_module);
+#endif
+#endif

--- a/code/numpy/fft/fft.h
+++ b/code/numpy/fft/fft.h
@@ -17,7 +17,7 @@
 #include "../../ndarray.h"
 #include "fft_tools.h"
 
-extern mp_obj_module_t ulab_fft_module;
+extern const mp_obj_module_t ulab_fft_module;
 
 #if ULAB_SUPPORTS_COMPLEX & ULAB_FFT_IS_NUMPY_COMPATIBLE
 MP_DECLARE_CONST_FUN_OBJ_3(fft_fft_obj);

--- a/code/numpy/io/io.c
+++ b/code/numpy/io/io.c
@@ -32,7 +32,7 @@
 #define ULAB_IO_BIG_ENDIAN          2
 
 #if ULAB_NUMPY_HAS_LOAD
-static void io_read_(mp_obj_t stream, const mp_stream_p_t *stream_p, char *buffer, char *string, uint16_t len, int *error) {
+static void io_read_(mp_obj_t stream, const mp_stream_p_t *stream_p, char *buffer, const char *string, uint16_t len, int *error) {
     size_t read = stream_p->read(stream, buffer, len, error);
     bool fail = false;
     if(read == len) {
@@ -668,7 +668,7 @@ MP_DEFINE_CONST_FUN_OBJ_2(io_save_obj, io_save);
 #endif /* ULAB_NUMPY_HAS_SAVE */
 
 #if ULAB_NUMPY_HAS_SAVETXT
-static int8_t io_format_float(ndarray_obj_t *ndarray, mp_float_t (*func)(void *), uint8_t *array, char *buffer, char *delimiter) {
+static int8_t io_format_float(ndarray_obj_t *ndarray, mp_float_t (*func)(void *), uint8_t *array, char *buffer, const char *delimiter) {
     // own implementation of float formatting for platforms that don't have sprintf
     int8_t offset = 0;
 

--- a/code/numpy/linalg/linalg.c
+++ b/code/numpy/linalg/linalg.c
@@ -536,6 +536,11 @@ const mp_obj_module_t ulab_linalg_module = {
     .base = { &mp_type_module },
     .globals = (mp_obj_dict_t*)&mp_module_ulab_linalg_globals,
 };
-MP_REGISTER_MODULE(MP_QSTR_ulab_dot_linalg, ulab_linalg_module, MODULE_ULAB_ENABLED && CIRCUITPY_ULAB);
-
+#if CIRCUITPY_ULAB
+#if !defined(MICROPY_VERSION) || MICROPY_VERSION <= 70144
+MP_REGISTER_MODULE(MP_QSTR_ulab_dot_numpy_dot_linalg, ulab_linalg_module, MODULE_ULAB_ENABLED);
+#else
+MP_REGISTER_MODULE(MP_QSTR_ulab_dot_numpy_dot_linalg, ulab_linalg_module);
+#endif
+#endif
 #endif

--- a/code/numpy/linalg/linalg.c
+++ b/code/numpy/linalg/linalg.c
@@ -532,9 +532,10 @@ STATIC const mp_rom_map_elem_t ulab_linalg_globals_table[] = {
 
 STATIC MP_DEFINE_CONST_DICT(mp_module_ulab_linalg_globals, ulab_linalg_globals_table);
 
-mp_obj_module_t ulab_linalg_module = {
+const mp_obj_module_t ulab_linalg_module = {
     .base = { &mp_type_module },
     .globals = (mp_obj_dict_t*)&mp_module_ulab_linalg_globals,
 };
+MP_REGISTER_MODULE(MP_QSTR_ulab_dot_linalg, ulab_linalg_module, MODULE_ULAB_ENABLED && CIRCUITPY_ULAB);
 
 #endif

--- a/code/numpy/linalg/linalg.h
+++ b/code/numpy/linalg/linalg.h
@@ -16,7 +16,7 @@
 #include "../../ndarray.h"
 #include "linalg_tools.h"
 
-extern mp_obj_module_t ulab_linalg_module;
+extern const mp_obj_module_t ulab_linalg_module;
 
 MP_DECLARE_CONST_FUN_OBJ_1(linalg_cholesky_obj);
 MP_DECLARE_CONST_FUN_OBJ_1(linalg_det_obj);

--- a/code/numpy/numpy.c
+++ b/code/numpy/numpy.c
@@ -374,4 +374,10 @@ const mp_obj_module_t ulab_numpy_module = {
     .globals = (mp_obj_dict_t*)&mp_module_ulab_numpy_globals,
 };
 
-MP_REGISTER_MODULE(MP_QSTR_ulab_dot_numpy, ulab_numpy_module, MODULE_ULAB_ENABLED && CIRCUITPY_ULAB);
+#if CIRCUITPY_ULAB
+#if !defined(MICROPY_VERSION) || MICROPY_VERSION <= 70144
+MP_REGISTER_MODULE(MP_QSTR_ulab_dot_numpy, ulab_numpy_module, MODULE_ULAB_ENABLED);
+#else
+MP_REGISTER_MODULE(MP_QSTR_ulab_dot_numpy, ulab_numpy_module);
+#endif
+#endif

--- a/code/numpy/numpy.c
+++ b/code/numpy/numpy.c
@@ -369,7 +369,9 @@ static const mp_rom_map_elem_t ulab_numpy_globals_table[] = {
 
 static MP_DEFINE_CONST_DICT(mp_module_ulab_numpy_globals, ulab_numpy_globals_table);
 
-mp_obj_module_t ulab_numpy_module = {
+const mp_obj_module_t ulab_numpy_module = {
     .base = { &mp_type_module },
     .globals = (mp_obj_dict_t*)&mp_module_ulab_numpy_globals,
 };
+
+MP_REGISTER_MODULE(MP_QSTR_ulab_dot_numpy, ulab_numpy_module, MODULE_ULAB_ENABLED && CIRCUITPY_ULAB);

--- a/code/numpy/numpy.h
+++ b/code/numpy/numpy.h
@@ -16,6 +16,6 @@
 #include "../ulab.h"
 #include "../ndarray.h"
 
-extern mp_obj_module_t ulab_numpy_module;
+extern const mp_obj_module_t ulab_numpy_module;
 
 #endif /* _NUMPY_ */

--- a/code/scipy/linalg/linalg.c
+++ b/code/scipy/linalg/linalg.c
@@ -275,6 +275,11 @@ const mp_obj_module_t ulab_scipy_linalg_module = {
     .base = { &mp_type_module },
     .globals = (mp_obj_dict_t*)&mp_module_ulab_scipy_linalg_globals,
 };
-MP_REGISTER_MODULE(MP_QSTR_ulab_dot_scipy_dot_linalg, ulab_scipy_linalg_module, MODULE_ULAB_ENABLED && CIRCUITPY_ULAB);
-
+#if CIRCUITPY_ULAB
+#if !defined(MICROPY_VERSION) || MICROPY_VERSION <= 70144
+MP_REGISTER_MODULE(MP_QSTR_ulab_dot_scipy_dot_linalg, ulab_scipy_linalg_module, MODULE_ULAB_ENABLED);
+#else
+MP_REGISTER_MODULE(MP_QSTR_ulab_dot_scipy_dot_linalg, ulab_scipy_linalg_module);
+#endif
+#endif
 #endif

--- a/code/scipy/linalg/linalg.c
+++ b/code/scipy/linalg/linalg.c
@@ -271,9 +271,10 @@ static const mp_rom_map_elem_t ulab_scipy_linalg_globals_table[] = {
 
 static MP_DEFINE_CONST_DICT(mp_module_ulab_scipy_linalg_globals, ulab_scipy_linalg_globals_table);
 
-mp_obj_module_t ulab_scipy_linalg_module = {
+const mp_obj_module_t ulab_scipy_linalg_module = {
     .base = { &mp_type_module },
     .globals = (mp_obj_dict_t*)&mp_module_ulab_scipy_linalg_globals,
 };
+MP_REGISTER_MODULE(MP_QSTR_ulab_dot_scipy_dot_linalg, ulab_scipy_linalg_module, MODULE_ULAB_ENABLED && CIRCUITPY_ULAB);
 
 #endif

--- a/code/scipy/linalg/linalg.h
+++ b/code/scipy/linalg/linalg.h
@@ -13,7 +13,7 @@
 #ifndef _SCIPY_LINALG_
 #define _SCIPY_LINALG_
 
-extern mp_obj_module_t ulab_scipy_linalg_module;
+extern const mp_obj_module_t ulab_scipy_linalg_module;
 
 MP_DECLARE_CONST_FUN_OBJ_KW(linalg_solve_triangular_obj);
 MP_DECLARE_CONST_FUN_OBJ_2(linalg_cho_solve_obj);

--- a/code/scipy/optimize/optimize.c
+++ b/code/scipy/optimize/optimize.c
@@ -412,4 +412,10 @@ const mp_obj_module_t ulab_scipy_optimize_module = {
     .base = { &mp_type_module },
     .globals = (mp_obj_dict_t*)&mp_module_ulab_scipy_optimize_globals,
 };
-MP_REGISTER_MODULE(MP_QSTR_ulab_dot_scipy_dot_optimize, ulab_scipy_optimize_module, MODULE_ULAB_ENABLED && CIRCUITPY_ULAB);
+#if CIRCUITPY_ULAB
+#if !defined(MICROPY_VERSION) || MICROPY_VERSION <= 70144
+MP_REGISTER_MODULE(MP_QSTR_ulab_dot_scipy_dot_optimize, ulab_scipy_optimize_module, MODULE_ULAB_ENABLED);
+#else
+MP_REGISTER_MODULE(MP_QSTR_ulab_dot_scipy_dot_optimize, ulab_scipy_optimize_module);
+#endif
+#endif

--- a/code/scipy/optimize/optimize.c
+++ b/code/scipy/optimize/optimize.c
@@ -408,7 +408,8 @@ static const mp_rom_map_elem_t ulab_scipy_optimize_globals_table[] = {
 
 static MP_DEFINE_CONST_DICT(mp_module_ulab_scipy_optimize_globals, ulab_scipy_optimize_globals_table);
 
-mp_obj_module_t ulab_scipy_optimize_module = {
+const mp_obj_module_t ulab_scipy_optimize_module = {
     .base = { &mp_type_module },
     .globals = (mp_obj_dict_t*)&mp_module_ulab_scipy_optimize_globals,
 };
+MP_REGISTER_MODULE(MP_QSTR_ulab_dot_scipy_dot_optimize, ulab_scipy_optimize_module, MODULE_ULAB_ENABLED && CIRCUITPY_ULAB);

--- a/code/scipy/optimize/optimize.h
+++ b/code/scipy/optimize/optimize.h
@@ -31,7 +31,7 @@
 #define     OPTIMIZE_GAMMA        MICROPY_FLOAT_CONST(0.5)
 #define     OPTIMIZE_DELTA        MICROPY_FLOAT_CONST(0.5)
 
-extern mp_obj_module_t ulab_scipy_optimize_module;
+extern const mp_obj_module_t ulab_scipy_optimize_module;
 
 MP_DECLARE_CONST_FUN_OBJ_KW(optimize_bisect_obj);
 MP_DECLARE_CONST_FUN_OBJ_KW(optimize_curve_fit_obj);

--- a/code/scipy/scipy.c
+++ b/code/scipy/scipy.c
@@ -44,8 +44,9 @@ static const mp_rom_map_elem_t ulab_scipy_globals_table[] = {
 
 static MP_DEFINE_CONST_DICT(mp_module_ulab_scipy_globals, ulab_scipy_globals_table);
 
-mp_obj_module_t ulab_scipy_module = {
+const mp_obj_module_t ulab_scipy_module = {
     .base = { &mp_type_module },
     .globals = (mp_obj_dict_t*)&mp_module_ulab_scipy_globals,
 };
+MP_REGISTER_MODULE(MP_QSTR_ulab_dot_scipy, ulab_scipy_module, MODULE_ULAB_ENABLED && CIRCUITPY_ULAB);
 #endif /* ULAB_HAS_SCIPY */

--- a/code/scipy/scipy.c
+++ b/code/scipy/scipy.c
@@ -48,5 +48,11 @@ const mp_obj_module_t ulab_scipy_module = {
     .base = { &mp_type_module },
     .globals = (mp_obj_dict_t*)&mp_module_ulab_scipy_globals,
 };
-MP_REGISTER_MODULE(MP_QSTR_ulab_dot_scipy, ulab_scipy_module, MODULE_ULAB_ENABLED && CIRCUITPY_ULAB);
+#if CIRCUITPY_ULAB
+#if !defined(MICROPY_VERSION) || MICROPY_VERSION <= 70144
+MP_REGISTER_MODULE(MP_QSTR_ulab_dot_scipy, ulab_scipy_module, MODULE_ULAB_ENABLED);
+#else
+MP_REGISTER_MODULE(MP_QSTR_ulab_dot_scipy, ulab_scipy_module);
+#endif
+#endif
 #endif /* ULAB_HAS_SCIPY */

--- a/code/scipy/scipy.h
+++ b/code/scipy/scipy.h
@@ -16,6 +16,6 @@
 #include "../ulab.h"
 #include "../ndarray.h"
 
-extern mp_obj_module_t ulab_scipy_module;
+extern const mp_obj_module_t ulab_scipy_module;
 
 #endif /* _SCIPY_ */

--- a/code/scipy/signal/signal.c
+++ b/code/scipy/signal/signal.c
@@ -129,7 +129,8 @@ static const mp_rom_map_elem_t ulab_scipy_signal_globals_table[] = {
 
 static MP_DEFINE_CONST_DICT(mp_module_ulab_scipy_signal_globals, ulab_scipy_signal_globals_table);
 
-mp_obj_module_t ulab_scipy_signal_module = {
+const mp_obj_module_t ulab_scipy_signal_module = {
     .base = { &mp_type_module },
     .globals = (mp_obj_dict_t*)&mp_module_ulab_scipy_signal_globals,
 };
+MP_REGISTER_MODULE(MP_QSTR_ulab_dot_scipy_dot_signal, ulab_scipy_signal_module, MODULE_ULAB_ENABLED && CIRCUITPY_ULAB);

--- a/code/scipy/signal/signal.c
+++ b/code/scipy/signal/signal.c
@@ -133,4 +133,10 @@ const mp_obj_module_t ulab_scipy_signal_module = {
     .base = { &mp_type_module },
     .globals = (mp_obj_dict_t*)&mp_module_ulab_scipy_signal_globals,
 };
-MP_REGISTER_MODULE(MP_QSTR_ulab_dot_scipy_dot_signal, ulab_scipy_signal_module, MODULE_ULAB_ENABLED && CIRCUITPY_ULAB);
+#if CIRCUITPY_ULAB
+#if !defined(MICROPY_VERSION) || MICROPY_VERSION <= 70144
+MP_REGISTER_MODULE(MP_QSTR_ulab_dot_scipy_dot_signal, ulab_scipy_signal_module, MODULE_ULAB_ENABLED);
+#else
+MP_REGISTER_MODULE(MP_QSTR_ulab_dot_scipy_dot_signal, ulab_scipy_signal_module);
+#endif
+#endif

--- a/code/scipy/signal/signal.h
+++ b/code/scipy/signal/signal.h
@@ -16,7 +16,7 @@
 #include "../../ulab.h"
 #include "../../ndarray.h"
 
-extern mp_obj_module_t ulab_scipy_signal_module;
+extern const mp_obj_module_t ulab_scipy_signal_module;
 
 MP_DECLARE_CONST_FUN_OBJ_KW(signal_sosfilt_obj);
 

--- a/code/scipy/special/special.c
+++ b/code/scipy/special/special.c
@@ -36,7 +36,8 @@ static const mp_rom_map_elem_t ulab_scipy_special_globals_table[] = {
 
 static MP_DEFINE_CONST_DICT(mp_module_ulab_scipy_special_globals, ulab_scipy_special_globals_table);
 
-mp_obj_module_t ulab_scipy_special_module = {
+const mp_obj_module_t ulab_scipy_special_module = {
     .base = { &mp_type_module },
     .globals = (mp_obj_dict_t*)&mp_module_ulab_scipy_special_globals,
 };
+MP_REGISTER_MODULE(MP_QSTR_ulab_dot_scipy_dot_special, ulab_scipy_special_module, MODULE_ULAB_ENABLED && CIRCUITPY_ULAB);

--- a/code/scipy/special/special.c
+++ b/code/scipy/special/special.c
@@ -40,4 +40,10 @@ const mp_obj_module_t ulab_scipy_special_module = {
     .base = { &mp_type_module },
     .globals = (mp_obj_dict_t*)&mp_module_ulab_scipy_special_globals,
 };
-MP_REGISTER_MODULE(MP_QSTR_ulab_dot_scipy_dot_special, ulab_scipy_special_module, MODULE_ULAB_ENABLED && CIRCUITPY_ULAB);
+#if CIRCUITPY_ULAB
+#if !defined(MICROPY_VERSION) || MICROPY_VERSION <= 70144
+MP_REGISTER_MODULE(MP_QSTR_ulab_dot_scipy_dot_special, ulab_scipy_special_module, MODULE_ULAB_ENABLED);
+#else
+MP_REGISTER_MODULE(MP_QSTR_ulab_dot_scipy_dot_special, ulab_scipy_special_module);
+#endif
+#endif

--- a/code/scipy/special/special.h
+++ b/code/scipy/special/special.h
@@ -16,6 +16,6 @@
 #include "../../ulab.h"
 #include "../../ndarray.h"
 
-extern mp_obj_module_t ulab_scipy_special_module;
+extern const mp_obj_module_t ulab_scipy_special_module;
 
 #endif /* _SCIPY_SPECIAL_ */

--- a/code/ulab.c
+++ b/code/ulab.c
@@ -162,15 +162,15 @@ STATIC const mp_rom_map_elem_t ulab_globals_table[] = {
         { MP_ROM_QSTR(MP_QSTR_dtype), MP_ROM_PTR(&ndarray_dtype_obj) },
         #endif /* NDARRAY_HAS_DTYPE */
     #endif /* ULAB_HAS_DTYPE_OBJECT */
-        { MP_ROM_QSTR(MP_QSTR_numpy), MP_ROM_PTR(&ulab_numpy_module) },
+        { MP_ROM_QSTR(MP_QSTR_numpy), MP_ROM_PTR((mp_obj_t)&ulab_numpy_module) },
     #if ULAB_HAS_SCIPY
-        { MP_ROM_QSTR(MP_QSTR_scipy), MP_ROM_PTR(&ulab_scipy_module) },
+        { MP_ROM_QSTR(MP_QSTR_scipy), MP_ROM_PTR((mp_obj_t)&ulab_scipy_module) },
     #endif
     #if ULAB_HAS_USER_MODULE
-        { MP_ROM_QSTR(MP_QSTR_user), MP_ROM_PTR(&ulab_user_module) },
+        { MP_ROM_QSTR(MP_QSTR_user), MP_ROM_PTR((mp_obj_t)&ulab_user_module) },
     #endif
     #if ULAB_HAS_UTILS_MODULE
-        { MP_ROM_QSTR(MP_QSTR_utils), MP_ROM_PTR(&ulab_utils_module) },
+        { MP_ROM_QSTR(MP_QSTR_utils), MP_ROM_PTR((mp_obj_t)&ulab_utils_module) },
     #endif
 };
 

--- a/code/ulab.c
+++ b/code/ulab.c
@@ -190,7 +190,7 @@ const mp_obj_module_t ulab_user_cmodule = {
 
 // Use old three-argument MP_REGISTER_MODULE for
 // MicroPython <= v1.18.0: (1 << 16) | (18 << 8) | 0
-#if MICROPY_VERSION <= 70144
+#if !defined(MICROPY_VERSION) || MICROPY_VERSION <= 70144
 MP_REGISTER_MODULE(MP_QSTR_ulab, ulab_user_cmodule, MODULE_ULAB_ENABLED);
 #else
 MP_REGISTER_MODULE(MP_QSTR_ulab, ulab_user_cmodule);

--- a/code/ulab.c
+++ b/code/ulab.c
@@ -33,7 +33,7 @@
 #include "user/user.h"
 #include "utils/utils.h"
 
-#define ULAB_VERSION 5.0.8
+#define ULAB_VERSION 5.0.9
 #define xstr(s) str(s)
 #define str(s) #s
 

--- a/code/ulab.c
+++ b/code/ulab.c
@@ -162,15 +162,15 @@ STATIC const mp_rom_map_elem_t ulab_globals_table[] = {
         { MP_ROM_QSTR(MP_QSTR_dtype), MP_ROM_PTR(&ndarray_dtype_obj) },
         #endif /* NDARRAY_HAS_DTYPE */
     #endif /* ULAB_HAS_DTYPE_OBJECT */
-        { MP_ROM_QSTR(MP_QSTR_numpy), MP_ROM_PTR((mp_obj_t)&ulab_numpy_module) },
+        { MP_ROM_QSTR(MP_QSTR_numpy), MP_ROM_PTR(&ulab_numpy_module) },
     #if ULAB_HAS_SCIPY
-        { MP_ROM_QSTR(MP_QSTR_scipy), MP_ROM_PTR((mp_obj_t)&ulab_scipy_module) },
+        { MP_ROM_QSTR(MP_QSTR_scipy), MP_ROM_PTR(&ulab_scipy_module) },
     #endif
     #if ULAB_HAS_USER_MODULE
-        { MP_ROM_QSTR(MP_QSTR_user), MP_ROM_PTR((mp_obj_t)&ulab_user_module) },
+        { MP_ROM_QSTR(MP_QSTR_user), MP_ROM_PTR(&ulab_user_module) },
     #endif
     #if ULAB_HAS_UTILS_MODULE
-        { MP_ROM_QSTR(MP_QSTR_utils), MP_ROM_PTR((mp_obj_t)&ulab_utils_module) },
+        { MP_ROM_QSTR(MP_QSTR_utils), MP_ROM_PTR(&ulab_utils_module) },
     #endif
 };
 

--- a/code/user/user.c
+++ b/code/user/user.c
@@ -91,6 +91,12 @@ const mp_obj_module_t ulab_user_module = {
     .base = { &mp_type_module },
     .globals = (mp_obj_dict_t*)&mp_module_ulab_user_globals,
 };
-MP_REGISTER_MODULE(MP_QSTR_ulab_dot_user, ulab_user_module, ULAB_HAS_USER_MODULE && CIRCUITPY_ULAB);
+#if CIRCUITPY_ULAB
+#if !defined(MICROPY_VERSION) || MICROPY_VERSION <= 70144
+MP_REGISTER_MODULE(MP_QSTR_ulab_dot_user, ulab_user_module, ULAB_HAS_USER_MODULE);
+#else
+MP_REGISTER_MODULE(MP_QSTR_ulab_dot_user, ulab_user_module);
+#endif
+#endif
 
 #endif

--- a/code/user/user.c
+++ b/code/user/user.c
@@ -87,9 +87,10 @@ static const mp_rom_map_elem_t ulab_user_globals_table[] = {
 
 static MP_DEFINE_CONST_DICT(mp_module_ulab_user_globals, ulab_user_globals_table);
 
-mp_obj_module_t ulab_user_module = {
+const mp_obj_module_t ulab_user_module = {
     .base = { &mp_type_module },
     .globals = (mp_obj_dict_t*)&mp_module_ulab_user_globals,
 };
+MP_REGISTER_MODULE(MP_QSTR_ulab_dot_user, ulab_user_module, ULAB_HAS_USER_MODULE && CIRCUITPY_ULAB);
 
 #endif

--- a/code/user/user.h
+++ b/code/user/user.h
@@ -15,6 +15,6 @@
 #include "../ulab.h"
 #include "../ndarray.h"
 
-extern mp_obj_module_t ulab_user_module;
+extern const mp_obj_module_t ulab_user_module;
 
 #endif

--- a/code/utils/utils.c
+++ b/code/utils/utils.c
@@ -245,9 +245,10 @@ static const mp_rom_map_elem_t ulab_utils_globals_table[] = {
 
 static MP_DEFINE_CONST_DICT(mp_module_ulab_utils_globals, ulab_utils_globals_table);
 
-mp_obj_module_t ulab_utils_module = {
+const mp_obj_module_t ulab_utils_module = {
     .base = { &mp_type_module },
     .globals = (mp_obj_dict_t*)&mp_module_ulab_utils_globals,
 };
+MP_REGISTER_MODULE(MP_QSTR_ulab_dot_utils, ulab_utils_module, MODULE_ULAB_ENABLED && CIRCUITPY_ULAB);
 
 #endif /* ULAB_HAS_UTILS_MODULE */

--- a/code/utils/utils.c
+++ b/code/utils/utils.c
@@ -249,6 +249,12 @@ const mp_obj_module_t ulab_utils_module = {
     .base = { &mp_type_module },
     .globals = (mp_obj_dict_t*)&mp_module_ulab_utils_globals,
 };
-MP_REGISTER_MODULE(MP_QSTR_ulab_dot_utils, ulab_utils_module, MODULE_ULAB_ENABLED && CIRCUITPY_ULAB);
+#if CIRCUITPY_ULAB
+#if !defined(MICROPY_VERSION) || MICROPY_VERSION <= 70144
+MP_REGISTER_MODULE(MP_QSTR_ulab_dot_utils, ulab_utils_module, MODULE_ULAB_ENABLED);
+#else
+MP_REGISTER_MODULE(MP_QSTR_ulab_dot_utils, ulab_utils_module);
+#endif
+#endif
 
 #endif /* ULAB_HAS_UTILS_MODULE */

--- a/code/utils/utils.h
+++ b/code/utils/utils.h
@@ -14,6 +14,6 @@
 #include "../ulab.h"
 #include "../ndarray.h"
 
-extern mp_obj_module_t ulab_utils_module;
+extern const mp_obj_module_t ulab_utils_module;
 
 #endif


### PR DESCRIPTION
These errors actually occurred when building the raspberry pi pico port; they weren't deteted when building the unix port during ulab ci, as this does not enable the diagnostics -Werror=undefined or -Werror=discarded-qualifiers.