### PR TITLE
fix use of MICROPY_FLOAT_CONST, and build single-precision as part of CI

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -50,6 +50,9 @@ make -C micropython/ports/unix -j${NPROC} USER_C_MODULES="${HERE}" DEBUG=1 STRIP
 
 bash test-common.sh "${dims}" "micropython/ports/unix/micropython-$dims"
 
+# Build with single-precision float.
+make -C micropython/ports/unix -j${NPROC} USER_C_MODULES="${HERE}" DEBUG=1 STRIP=: MICROPY_PY_FFI=0 MICROPY_PY_BTREE=0 CFLAGS_EXTRA=-DMICROPY_FLOAT_IMPL=MICROPY_FLOAT_IMPL_FLOAT CFLAGS_EXTRA+=-DULAB_MAX_DIMS=$dims CFLAGS_EXTRA+=-DULAB_HASH=$GIT_HASH BUILD=build-nanbox-$dims PROG=micropython-nanbox-$dims
+
 # The unix nanbox variant builds as a 32-bit executable and requires gcc-multilib.
 # macOS doesn't support i386 builds so only build on linux.
 if [ $PLATFORM = linux ]; then

--- a/code/ndarray.h
+++ b/code/ndarray.h
@@ -47,7 +47,7 @@
 // Use ULAB_REFERENCE_FLOAT_CONST to reference a constant float object in code.
 
 #define ULAB_DEFINE_FLOAT_CONST(id, num, hex32, hex64) \
-    const mp_obj_float_t id##_obj = {{&mp_type_float}, MICROPY_FLOAT_CONST(num)}
+    const mp_obj_float_t id##_obj = {{&mp_type_float}, (num)}
 
 #define ULAB_REFERENCE_FLOAT_CONST(id) MP_ROM_PTR(&id##_obj)
 

--- a/code/numpy/approx.c
+++ b/code/numpy/approx.c
@@ -25,7 +25,7 @@
 //| """Numerical approximation methods"""
 //|
 
-ULAB_DEFINE_FLOAT_CONST(approx_trapz_dx, 1.0, 0x3f800000UL, 0x3ff0000000000000ULL);
+ULAB_DEFINE_FLOAT_CONST(approx_trapz_dx, MICROPY_FLOAT_CONST(1.0), 0x3f800000UL, 0x3ff0000000000000ULL);
 
 #if ULAB_NUMPY_HAS_INTERP
 //| def interp(

--- a/code/numpy/create.c
+++ b/code/numpy/create.c
@@ -676,7 +676,7 @@ MP_DEFINE_CONST_FUN_OBJ_KW(create_linspace_obj, 2, create_linspace);
 //|     ...
 //|
 
-ULAB_DEFINE_FLOAT_CONST(const_ten, 10.0, 0x41200000UL, 0x4024000000000000ULL);
+ULAB_DEFINE_FLOAT_CONST(const_ten, MICROPY_FLOAT_CONST(10.0), 0x41200000UL, 0x4024000000000000ULL);
 
 mp_obj_t create_logspace(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     static const mp_arg_t allowed_args[] = {

--- a/code/numpy/numpy.c
+++ b/code/numpy/numpy.c
@@ -57,19 +57,19 @@
 
 // math constants
 #if ULAB_NUMPY_HAS_E
-ULAB_DEFINE_FLOAT_CONST(ulab_const_float_e, MP_E+0., 0x402df854UL, 0x4005bf0a8b145769ULL);
+ULAB_DEFINE_FLOAT_CONST(ulab_const_float_e, MP_E, 0x402df854UL, 0x4005bf0a8b145769ULL);
 #endif
 
 #if ULAB_NUMPY_HAS_INF
-ULAB_DEFINE_FLOAT_CONST(numpy_const_float_inf, (mp_float_t)INFINITY+0., 0x7f800000UL, 0x7ff0000000000000ULL);
+ULAB_DEFINE_FLOAT_CONST(numpy_const_float_inf, (mp_float_t)INFINITY, 0x7f800000UL, 0x7ff0000000000000ULL);
 #endif
 
 #if ULAB_NUMPY_HAS_NAN
-ULAB_DEFINE_FLOAT_CONST(numpy_const_float_nan, (mp_float_t)NAN+0., 0x7fc00000UL, 0x7ff8000000000000ULL);
+ULAB_DEFINE_FLOAT_CONST(numpy_const_float_nan, (mp_float_t)NAN, 0x7fc00000UL, 0x7ff8000000000000ULL);
 #endif
 
 #if ULAB_NUMPY_HAS_PI
-ULAB_DEFINE_FLOAT_CONST(ulab_const_float_pi, (mp_float_t)MP_PI+0., 0x40490fdbUL, 0x400921fb54442d18ULL);
+ULAB_DEFINE_FLOAT_CONST(ulab_const_float_pi, MP_PI, 0x40490fdbUL, 0x400921fb54442d18ULL);
 #endif
 
 static const mp_rom_map_elem_t ulab_numpy_globals_table[] = {

--- a/code/scipy/optimize/optimize.c
+++ b/code/scipy/optimize/optimize.c
@@ -22,8 +22,8 @@
 #include "../../ulab_tools.h"
 #include "optimize.h"
 
-ULAB_DEFINE_FLOAT_CONST(xtolerance, 2.4e-7, 0x3480d959UL, 0x3e901b2b29a4692bULL);
-ULAB_DEFINE_FLOAT_CONST(rtolerance, 0.0, 0UL, 0ULL);
+ULAB_DEFINE_FLOAT_CONST(xtolerance, MICROPY_FLOAT_CONST(2.4e-7), 0x3480d959UL, 0x3e901b2b29a4692bULL);
+ULAB_DEFINE_FLOAT_CONST(rtolerance, MICROPY_FLOAT_CONST(0.0), 0UL, 0ULL);
 
 static mp_float_t optimize_python_call(const mp_obj_type_t *type, mp_obj_t fun, mp_float_t x, mp_obj_t *fargs, uint8_t nparams) {
     // Helper function for calculating the value of f(x, a, b, c, ...),


### PR DESCRIPTION
Follow on from #534.