### PR TITLE
fix: remove make axtls, added make submodules

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -45,7 +45,7 @@ HERE="$(dirname -- "$(readlinkf_posix -- "${0}")" )"
 [ -e micropython/lib/axtls/README ] || (cd micropython && git submodule update --init lib/axtls )
 dims=${1-2}
 make -C micropython/mpy-cross -j${NPROC}
-make -C micropython/ports/unix -j${NPROC} axtls
+make -C micropython/ports/unix submodules
 make -C micropython/ports/unix -j${NPROC} USER_C_MODULES="${HERE}" DEBUG=1 STRIP=: MICROPY_PY_FFI=0 MICROPY_PY_BTREE=0 CFLAGS_EXTRA=-DULAB_MAX_DIMS=$dims CFLAGS_EXTRA+=-DULAB_HASH=$GIT_HASH BUILD=build-$dims PROG=micropython-$dims
 
 bash test-common.sh "${dims}" "micropython/ports/unix/micropython-$dims"


### PR DESCRIPTION
There has been an update with the new build instructions for micropython as found [here](https://github.com/micropython/micropython#the-unix-version)