### PR TITLE
Added test script for np.nonzero()

### DIFF
--- a/tests/2d/numpy/nonzero.py
+++ b/tests/2d/numpy/nonzero.py
@@ -1,0 +1,17 @@
+try:
+   from ulab import numpy as np
+except:
+   import numpy as np
+
+array = np.array(range(16)).reshape((4,4))
+boolean_array = array < 3
+
+# np.nonzero() returns a tuple of corresponding row and column 
+# indices array for each element being true in boolean array
+row_indices, column_indices = np.nonzero(boolean_array)
+
+print("Given Array:\n", array)
+print("\nBoolean Array:\n", boolean_array)
+print("\nFollowing indices have non-zero values:")
+for i in range(len(row_indices)):
+	print("row", row_indices[i], "and column", column_indices[i])

--- a/tests/2d/numpy/nonzero.py
+++ b/tests/2d/numpy/nonzero.py
@@ -4,14 +4,13 @@ except:
    import numpy as np
 
 array = np.array(range(16)).reshape((4,4))
-boolean_array = array < 3
+print(array)
+print(array < 5)
+print(np.nonzero(array < 5))
 
-# np.nonzero() returns a tuple of corresponding row and column 
-# indices array for each element being true in boolean array
-row_indices, column_indices = np.nonzero(boolean_array)
+dtypes = (np.uint8, np.int8, np.uint16, np.int16, np.float)
 
-print("Given Array:\n", array)
-print("\nBoolean Array:\n", boolean_array)
-print("\nFollowing indices have non-zero values:")
-for i in range(len(row_indices)):
-	print("row", row_indices[i], "and column", column_indices[i])
+for dtype in dtypes:
+    array = (np.arange(2, 12, 3, dtype=dtype)).reshape((2,2)) - 2
+    print(array)
+    print(np.nonzero(array))

--- a/tests/2d/numpy/nonzero.py.exp
+++ b/tests/2d/numpy/nonzero.py.exp
@@ -1,0 +1,16 @@
+Given Array:
+ array([[0.0, 1.0, 2.0, 3.0],
+       [4.0, 5.0, 6.0, 7.0],
+       [8.0, 9.0, 10.0, 11.0],
+       [12.0, 13.0, 14.0, 15.0]], dtype=float64)
+
+Boolean Array:
+ array([[True, True, True, False],
+       [False, False, False, False],
+       [False, False, False, False],
+       [False, False, False, False]], dtype=bool)
+
+Following indices have non-zero values:
+row 0 and column 0
+row 0 and column 1
+row 0 and column 2

--- a/tests/2d/numpy/nonzero.py.exp
+++ b/tests/2d/numpy/nonzero.py.exp
@@ -1,16 +1,24 @@
-Given Array:
- array([[0.0, 1.0, 2.0, 3.0],
+array([[0.0, 1.0, 2.0, 3.0],
        [4.0, 5.0, 6.0, 7.0],
        [8.0, 9.0, 10.0, 11.0],
        [12.0, 13.0, 14.0, 15.0]], dtype=float64)
-
-Boolean Array:
- array([[True, True, True, False],
-       [False, False, False, False],
+array([[True, True, True, True],
+       [True, False, False, False],
        [False, False, False, False],
        [False, False, False, False]], dtype=bool)
-
-Following indices have non-zero values:
-row 0 and column 0
-row 0 and column 1
-row 0 and column 2
+(array([0, 0, 0, 0, 1], dtype=uint16), array([0, 1, 2, 3, 0], dtype=uint16))
+array([[0, 3],
+       [6, 9]], dtype=uint8)
+(array([0, 1, 1], dtype=uint16), array([1, 0, 1], dtype=uint16))
+array([[0, 3],
+       [6, 9]], dtype=int8)
+(array([0, 1, 1], dtype=uint16), array([1, 0, 1], dtype=uint16))
+array([[0, 3],
+       [6, 9]], dtype=uint16)
+(array([0, 1, 1], dtype=uint16), array([1, 0, 1], dtype=uint16))
+array([[0, 3],
+       [6, 9]], dtype=int16)
+(array([0, 1, 1], dtype=uint16), array([1, 0, 1], dtype=uint16))
+array([[0.0, 3.0],
+       [6.0, 9.0]], dtype=float64)
+(array([0, 1, 1], dtype=uint16), array([1, 0, 1], dtype=uint16))


### PR DESCRIPTION
added following script at `ulab/tests/2d/numpy/nonzero.py`
```python
try:
   from ulab import numpy as np
except:
   import numpy as np

array = np.array(range(16)).reshape((4,4))
boolean_array = array < 3

# np.nonzero() returns a tuple of corresponding row and column 
# indices array for each element being true in boolean array
row_indices, column_indices = np.nonzero(boolean_array)

print("Given Array:\n", array)
print("\nBoolean Array:\n", boolean_array)
print("\nFollowing indices have non-zero values:")
for i in range(len(row_indices)):
	print("row", row_indices[i], "and column", column_indices[i])
```
The expected output file is located at `ulab/tests/2d/numpy/nonzero.py.exp`
Expected output:
```
Given Array:
 array([[0.0, 1.0, 2.0, 3.0],
       [4.0, 5.0, 6.0, 7.0],
       [8.0, 9.0, 10.0, 11.0],
       [12.0, 13.0, 14.0, 15.0]], dtype=float64)

Boolean Array:
 array([[True, True, True, False],
       [False, False, False, False],
       [False, False, False, False],
       [False, False, False, False]], dtype=bool)

Following indices have non-zero values:
row 0 and column 0
row 0 and column 1
row 0 and column 2
```