### PR TITLE
Update mp_obj_type_t definitions for latest MicroPython.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -51,8 +51,13 @@ make -C micropython/mpy-cross -j${NPROC}
 make -C micropython/ports/unix submodules
 make -C micropython/ports/unix -j${NPROC} USER_C_MODULES="${HERE}" DEBUG=1 STRIP=: MICROPY_PY_FFI=0 MICROPY_PY_BTREE=0 CFLAGS_EXTRA=-DULAB_MAX_DIMS=$dims CFLAGS_EXTRA+=-DULAB_HASH=$GIT_HASH BUILD=build-$dims PROG=micropython-$dims
 
+PROG="micropython/ports/unix/build-$dims/micropython-$dims"
+if [ ! -e "$PROG" ]; then
+  # Older MicroPython revision, executable is still in ports/unix.
+  PROG="micropython/ports/unix/micropython-$dims"
+fi
 
-bash test-common.sh "${dims}" "micropython/ports/unix/micropython-$dims"
+bash test-common.sh "${dims}" "$PROG"
 
 # Build with single-precision float.
 make -C micropython/ports/unix -j${NPROC} USER_C_MODULES="${HERE}" DEBUG=1 STRIP=: MICROPY_PY_FFI=0 MICROPY_PY_BTREE=0 CFLAGS_EXTRA=-DMICROPY_FLOAT_IMPL=MICROPY_FLOAT_IMPL_FLOAT CFLAGS_EXTRA+=-DULAB_MAX_DIMS=$dims CFLAGS_EXTRA+=-DULAB_HASH=$GIT_HASH BUILD=build-nanbox-$dims PROG=micropython-nanbox-$dims

--- a/code/ndarray.h
+++ b/code/ndarray.h
@@ -93,11 +93,20 @@ typedef struct _mp_obj_slice_t {
 #define MP_ERROR_TEXT(x) x
 #endif
 
-#if !defined(MP_TYPE_FLAG_EXTENDED)
-#define MP_TYPE_CALL call
-#define mp_type_get_call_slot(t) t->call
+#if !defined(MP_OBJ_TYPE_GET_SLOT)
+#if defined(MP_TYPE_FLAG_EXTENDED)
+// Provide MP_OBJ_TYPE_{HAS,GET}_SLOT for CircuitPython.
+#define MP_OBJ_TYPE_HAS_SLOT(t, f) (mp_type_get_##f##_slot(t) != NULL)
+#define MP_OBJ_TYPE_GET_SLOT(t, f) mp_type_get_##f##_slot(t)
+#else
+// Provide MP_OBJ_TYPE_{HAS,GET}_SLOT for older revisions of MicroPython.
+#define MP_OBJ_TYPE_HAS_SLOT(t, f) ((t)->f != NULL)
+#define MP_OBJ_TYPE_GET_SLOT(t, f) (t)->f
+
+// Also allow CiruitPython-style mp_obj_type_t definitions.
 #define MP_TYPE_FLAG_EXTENDED (0)
 #define MP_TYPE_EXTENDED_FIELDS(...) __VA_ARGS__
+#endif
 #endif
 
 #if !CIRCUITPY

--- a/code/ndarray_properties.c
+++ b/code/ndarray_properties.c
@@ -31,18 +31,18 @@
 
 STATIC void call_local_method(mp_obj_t obj, qstr attr, mp_obj_t *dest) {
     const mp_obj_type_t *type = mp_obj_get_type(obj);
-    while (type->locals_dict != NULL) {
-        assert(type->locals_dict->base.type == &mp_type_dict); // MicroPython restriction, for now
-        mp_map_t *locals_map = &type->locals_dict->map;
+    while (MP_OBJ_TYPE_HAS_SLOT(type, locals_dict)) {
+        assert(MP_OBJ_TYPE_GET_SLOT(type, locals_dict)->base.type == &mp_type_dict); // MicroPython restriction, for now
+        mp_map_t *locals_map = &MP_OBJ_TYPE_GET_SLOT(type, locals_dict)->map;
         mp_map_elem_t *elem = mp_map_lookup(locals_map, MP_OBJ_NEW_QSTR(attr), MP_MAP_LOOKUP);
         if (elem != NULL) {
             mp_convert_member_lookup(obj, type, elem->value, dest);
             break;
         }
-        if (type->parent == NULL) {
+        if (!MP_OBJ_TYPE_HAS_SLOT(type, parent)) {
             break;
         }
-        type = type->parent;
+        type = MP_OBJ_TYPE_GET_SLOT(type, parent);
     }
 }
 

--- a/code/scipy/optimize/optimize.c
+++ b/code/scipy/optimize/optimize.c
@@ -30,7 +30,7 @@ static mp_float_t optimize_python_call(const mp_obj_type_t *type, mp_obj_t fun, 
     // where f is defined in python. Takes a float, returns a float.
     // The array of mp_obj_t type must be supplied, as must the number of parameters (a, b, c...) in nparams
     fargs[0] = mp_obj_new_float(x);
-    return mp_obj_get_float(type->MP_TYPE_CALL(fun, nparams+1, 0, fargs));
+    return mp_obj_get_float(MP_OBJ_TYPE_GET_SLOT(type, call)(fun, nparams+1, 0, fargs));
 }
 
 #if ULAB_SCIPY_OPTIMIZE_HAS_BISECT
@@ -70,7 +70,7 @@ STATIC mp_obj_t optimize_bisect(size_t n_args, const mp_obj_t *pos_args, mp_map_
 
     mp_obj_t fun = args[0].u_obj;
     const mp_obj_type_t *type = mp_obj_get_type(fun);
-    if(mp_type_get_call_slot(type) == NULL) {
+    if(!MP_OBJ_TYPE_HAS_SLOT(type, call)) {
         mp_raise_TypeError(translate("first argument must be a function"));
     }
     mp_float_t xtol = mp_obj_get_float(args[3].u_obj);
@@ -140,7 +140,7 @@ STATIC mp_obj_t optimize_fmin(size_t n_args, const mp_obj_t *pos_args, mp_map_t 
 
     mp_obj_t fun = args[0].u_obj;
     const mp_obj_type_t *type = mp_obj_get_type(fun);
-    if(mp_type_get_call_slot(type) == NULL) {
+    if(!MP_OBJ_TYPE_HAS_SLOT(type, call)) {
         mp_raise_TypeError(translate("first argument must be a function"));
     }
 
@@ -276,7 +276,7 @@ mp_obj_t optimize_curve_fit(size_t n_args, const mp_obj_t *pos_args, mp_map_t *k
 
     mp_obj_t fun = args[0].u_obj;
     const mp_obj_type_t *type = mp_obj_get_type(fun);
-    if(mp_type_get_call_slot(type) == NULL) {
+    if(!MP_OBJ_TYPE_HAS_SLOT(type, call)) {
         mp_raise_TypeError(translate("first argument must be a function"));
     }
 
@@ -365,7 +365,7 @@ static mp_obj_t optimize_newton(size_t n_args, const mp_obj_t *pos_args, mp_map_
 
     mp_obj_t fun = args[0].u_obj;
     const mp_obj_type_t *type = mp_obj_get_type(fun);
-    if(mp_type_get_call_slot(type) == NULL) {
+    if(!MP_OBJ_TYPE_HAS_SLOT(type, call)) {
         mp_raise_TypeError(translate("first argument must be a function"));
     }
     mp_float_t x = mp_obj_get_float(args[1].u_obj);

--- a/code/ulab.c
+++ b/code/ulab.c
@@ -100,6 +100,49 @@ STATIC const mp_rom_map_elem_t ulab_ndarray_locals_dict_table[] = {
 
 STATIC MP_DEFINE_CONST_DICT(ulab_ndarray_locals_dict, ulab_ndarray_locals_dict_table);
 
+#if defined(MP_DEFINE_CONST_OBJ_TYPE)
+// MicroPython after-b41aaaa (Sept 19 2022).
+
+#if NDARRAY_IS_SLICEABLE
+#define NDARRAY_TYPE_SUBSCR subscr, ndarray_subscr,
+#else
+#define NDARRAY_TYPE_SUBSCR
+#endif
+#if NDARRAY_IS_ITERABLE
+#define NDARRAY_TYPE_ITER iter, ndarray_getiter,
+#define NDARRAY_TYPE_ITER_FLAGS MP_TYPE_FLAG_ITER_IS_GETITER
+#else
+#define NDARRAY_TYPE_ITER
+#define NDARRAY_TYPE_ITER_FLAGS 0
+#endif
+#if NDARRAY_HAS_UNARY_OPS
+#define NDARRAY_TYPE_UNARY_OP unary_op, ndarray_unary_op,
+#else
+#define NDARRAY_TYPE_UNARY_OP
+#endif
+#if NDARRAY_HAS_BINARY_OPS
+#define NDARRAY_TYPE_BINARY_OP binary_op, ndarray_binary_op,
+#else
+#define NDARRAY_TYPE_BINARY_OP
+#endif
+
+MP_DEFINE_CONST_OBJ_TYPE(
+    ulab_ndarray_type,
+    MP_QSTR_ndarray,
+    MP_TYPE_FLAG_EQ_CHECKS_OTHER_TYPE | MP_TYPE_FLAG_EQ_HAS_NEQ_TEST | NDARRAY_TYPE_ITER_FLAGS,
+    print, ndarray_print,
+    make_new, ndarray_make_new,
+    locals_dict, &ulab_ndarray_locals_dict,
+    NDARRAY_TYPE_SUBSCR
+    NDARRAY_TYPE_ITER
+    NDARRAY_TYPE_UNARY_OP
+    NDARRAY_TYPE_BINARY_OP
+    attr, ndarray_properties_attr,
+    buffer, ndarray_get_buffer
+);
+
+#else
+// CircuitPython and earlier MicroPython revisions.
 const mp_obj_type_t ulab_ndarray_type = {
     { &mp_type_type },
     .flags = MP_TYPE_FLAG_EXTENDED
@@ -129,8 +172,19 @@ const mp_obj_type_t ulab_ndarray_type = {
     .buffer_p = { .get_buffer = ndarray_get_buffer, },
     )
 };
+#endif
 
 #if ULAB_HAS_DTYPE_OBJECT
+
+#if defined(MP_DEFINE_CONST_OBJ_TYPE)
+MP_DEFINE_CONST_OBJ_TYPE(
+    ulab_dtype_type,
+    MP_QSTR_dtype,
+    MP_TYPE_FLAG_NONE,
+    print, ndarray_dtype_print
+    make_new, ndarray_dtype_make_new
+);
+#else
 const mp_obj_type_t ulab_dtype_type = {
     { &mp_type_type },
     .name = MP_QSTR_dtype,
@@ -138,8 +192,17 @@ const mp_obj_type_t ulab_dtype_type = {
     .make_new = ndarray_dtype_make_new,
 };
 #endif
+#endif
 
 #if NDARRAY_HAS_FLATITER
+#if defined(MP_DEFINE_CONST_OBJ_TYPE)
+MP_DEFINE_CONST_OBJ_TYPE(
+    ndarray_flatiter_type,
+    MP_QSTR_flatiter,
+    MP_TYPE_FLAG_ITER_IS_GETITER,
+    iter, ndarray_get_flatiterator
+);
+#else
 const mp_obj_type_t ndarray_flatiter_type = {
     { &mp_type_type },
     .name = MP_QSTR_flatiter,
@@ -147,6 +210,7 @@ const mp_obj_type_t ndarray_flatiter_type = {
     .getiter = ndarray_get_flatiterator,
     )
 };
+#endif
 #endif
 
 STATIC const mp_rom_map_elem_t ulab_globals_table[] = {


### PR DESCRIPTION
https://github.com/micropython/micropython/pull/8813 changed the way that constant object type structs are defined in order to save ROM.

I have tried to maintain compatibility with CircuitPython, older-MicroPython-revisons. Hopefully CircuitPython will update to match the new style soon and the compatibility code can be removed.

Unfortunately I could not run the tests (from build.sh) as they don't pass for me even before updating the MicroPython version. This appears to be mostly around formatting of float printing (which is also something that has changed in MicroPython recently, but I tested it with v1.19.1 and it wasn't working there either). So that will need to be fixed before this can be merged, unfortunately I don't have the bandwidth to investigate that.

This PR also fixes build.sh to work with the change from https://github.com/micropython/micropython/pull/9012 that changes the output path for the unix port.