### PR TITLE
Check that array size doesn't overflow at construction time

### DIFF
--- a/code/ulab.c
+++ b/code/ulab.c
@@ -33,7 +33,7 @@
 #include "user/user.h"
 #include "utils/utils.h"
 
-#define ULAB_VERSION 6.0.4
+#define ULAB_VERSION 6.0.5
 #define xstr(s) str(s)
 #define str(s) #s
 

--- a/docs/ulab-change-log.md
+++ b/docs/ulab-change-log.md
@@ -1,4 +1,10 @@
 
+Sun, 21 Jan 2023
+
+version 6.0.5
+
+    fix ones()/zeros() method when the amount of memory to allocate overflows
+
 Sun, 15 Jan 2023
 
 version 6.0.4

--- a/tests/2d/numpy/zeros.py
+++ b/tests/2d/numpy/zeros.py
@@ -11,3 +11,18 @@ print(np.zeros((3,3)))
 for dtype in dtypes:
     print(np.zeros((3,3), dtype=dtype))
     print(np.zeros((4,2), dtype=dtype))
+
+try:
+    np.zeros((1<<31, 1<<31))
+except ValueError:
+    print("ValueError")
+
+try:
+    np.zeros((2147483653, 2147483649))
+except ValueError:
+    print("ValueError")
+
+try:
+    np.zeros((194899806, 189294637612))
+except ValueError:
+    print("ValueError")

--- a/tests/2d/numpy/zeros.py.exp
+++ b/tests/2d/numpy/zeros.py.exp
@@ -37,3 +37,6 @@ array([[0.0, 0.0],
        [0.0, 0.0],
        [0.0, 0.0],
        [0.0, 0.0]], dtype=float64)
+ValueError
+ValueError
+ValueError


### PR DESCRIPTION
Now, requesting to allocate an array directly from .ones() or .zeros() that is too big gives the exception 'array is too big', like numpy.

This does depend on a gcc extension, `__builtin_mul_overflow`, present since at least version 5. This extension is also supported in clang. msvc is probably the only compiler of note that does not support it.

Closes: #576

There are still a few suspicious allocations of multiplied sizes elsewhere, e.g., this one from poly.c:
```c
    XT = m_new(mp_float_t, (deg+1)*leny); // XT is a matrix of shape (deg+1, len) (rows, columns)                                                                                             
```
there are also some allocations of square arrays that are the same size as square arrays that already exist, so no overflow checking would be needed:
```c
    mp_float_t *tmp = m_new(mp_float_t, N * N);                                                                                                                                               
```