### PR TITLE
Use enum instead of const for float consts with repr C

### DIFF
--- a/code/ndarray.h
+++ b/code/ndarray.h
@@ -65,7 +65,9 @@ typedef struct _mp_obj_float_t {
 // See above for how to use ULAB_DEFINE_FLOAT_CONST and ULAB_REFERENCE_FLOAT_CONST.
 
 #define ULAB_DEFINE_FLOAT_CONST(id, num, hex32, hex64) \
-    const uint32_t id = (((((uint32_t)hex32) & ~3) | 2) + 0x80800000)
+    enum { \
+        id = (((((uint32_t)hex32) & ~3) | 2) + 0x80800000) \
+    }
 
 #define ULAB_REFERENCE_FLOAT_CONST(id) ((mp_obj_t)(id))
 


### PR DESCRIPTION
Older compilers (eg for esp8266) cannot see that "const uint32_t" is a true constant at compile time, so use an assigned enum instead.

Don't do this for object representation D because that requires a 64-bit integer.