### PR TITLE
Add a build script for Raspberry Pi Pico W

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,7 +363,7 @@ This file can be found in `$BUILD_DIR/micropython/ports/esp32/boards/TINYPICO/`.
 
 ### RP2-based boards
 
-RP2 firmware can be compiled either by downloading and running the single [build script](https://github.com/v923z/micropython-ulab/blob/master/build/rp2.sh), or executing the commands below.
+RP2 firmware can be compiled either by downloading and running the single [build script](https://github.com/v923z/micropython-ulab/blob/master/build/rp2.sh)/[build script for Pico W](https://github.com/v923z/micropython-ulab/blob/master/build/rp2w.sh), or executing the commands below.
 
 First, clone `micropython`:
 

--- a/build/rp2w.sh
+++ b/build/rp2w.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+export BOARD=PICO_W
+export BUILD_DIR=$(pwd)
+export MPY_DIR=$BUILD_DIR/micropython
+export ULAB_DIR=$BUILD_DIR/../code
+
+if [ ! -d $ULAB_DIR ]; then
+    printf "Cloning ulab\n"
+    ULAB_DIR=$BUILD_DIR/ulab/code
+    git clone https://github.com/v923z/micropython-ulab.git ulab
+fi
+
+if [ ! -d $MPY_DIR ]; then
+    printf "Cloning MicroPython\n"
+    git clone https://github.com/micropython/micropython.git micropython
+fi
+
+cd $MPY_DIR
+git submodule update --init
+cd ./mpy-cross && make # build cross-compiler (required)
+
+cd $MPY_DIR/ports/rp2
+make BOARD=$BOARD clean
+make USER_C_MODULES=$ULAB_DIR/micropython.cmake BOARD=$BOARD


### PR DESCRIPTION
In v923z/micropython-ulab, `build/rp2.sh` works fine for Raspberry Pi Pico but doesn't work for Pico W (the latest board with WiFi capability).
* I newly added a build script `build/rp2w.sh` for Pico W users.
* I also added a link in `README.md` to access the script.