### PR TITLE
Add a ULAB_PRINT_DTYPE constant

### DIFF
--- a/code/ndarray.c
+++ b/code/ndarray.c
@@ -525,6 +525,7 @@ void ndarray_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t ki
         ndarray_print_bracket(print, 0, self->shape[ULAB_MAX_DIMS-4], "]");
         #endif
     }
+    #if ULAB_PRINT_DTYPE
     mp_print_str(print, ", dtype=");
     if(self->boolean) {
         mp_print_str(print, "bool)");
@@ -549,6 +550,9 @@ void ndarray_print(const mp_print_t *print, mp_obj_t self_in, mp_print_kind_t ki
         mp_print_str(print, "float64)");
         #endif
     }
+    #else
+    mp_print_str(print, ")");
+    #endif
 }
 
 void ndarray_assign_elements(ndarray_obj_t *ndarray, mp_obj_t iterable, uint8_t dtype, size_t *idx) {

--- a/code/ulab.h
+++ b/code/ulab.h
@@ -74,6 +74,11 @@
 #define NDARRAY_PRINT_THRESHOLD             10
 #define NDARRAY_PRINT_EDGEITEMS             3
 
+// determines whether an array's dtype should be printed with the array
+#ifndef ULAB_PRINT_DTYPE
+#define ULAB_PRINT_DTYPE                    (1)
+#endif
+
 // determines, whether the dtype is an object, or simply a character
 // the object implementation is numpythonic, but requires more space
 #ifndef ULAB_HAS_DTYPE_OBJECT


### PR DESCRIPTION
I don't know if it is something you would like to add, but I added a small option for the display of "dtype=..." when printing an array.