### PR TITLE
Fix unused function compare_equal_helper warning

### DIFF
--- a/code/numpy/compare.c
+++ b/code/numpy/compare.c
@@ -125,6 +125,7 @@ static mp_obj_t compare_function(mp_obj_t x1, mp_obj_t x2, uint8_t op) {
     return mp_const_none; // we should never reach this point
 }
 
+#if ULAB_NUMPY_HAS_EQUAL | ULAB_NUMPY_HAS_NOTEQUAL
 static mp_obj_t compare_equal_helper(mp_obj_t x1, mp_obj_t x2, uint8_t comptype) {
     // scalar comparisons should return a single object of mp_obj_t type
     mp_obj_t result = compare_function(x1, x2, comptype);
@@ -136,6 +137,7 @@ static mp_obj_t compare_equal_helper(mp_obj_t x1, mp_obj_t x2, uint8_t comptype)
     }
     return result;
 }
+#endif
 
 #if ULAB_NUMPY_HAS_CLIP
 


### PR DESCRIPTION
A very small change to fix a warning when building with some features deactivated.