### PR TITLE
Fix arange crashing when start, stop or step is nan

### DIFF
--- a/code/numpy/create.c
+++ b/code/numpy/create.c
@@ -158,6 +158,10 @@ mp_obj_t create_arange(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_arg
         mp_raise_msg(&mp_type_ZeroDivisionError, MP_ERROR_TEXT("divide by zero"));
     }
 
+    if(isnan(start) || isnan(stop) || isnan(step)) {
+        mp_raise_ValueError(translate("arange: cannot compute length"));
+    }
+
     ndarray_obj_t *ndarray;
     if((stop - start)/step <= 0) {
         ndarray = ndarray_new_linear_array(0, dtype);
@@ -253,8 +257,6 @@ mp_obj_t create_concatenate(size_t n_args, const mp_obj_t *pos_args, mp_map_t *k
     int8_t axis = (int8_t)args[1].u_int;
     size_t *shape = m_new0(size_t, ULAB_MAX_DIMS);
     mp_obj_tuple_t *ndarrays = MP_OBJ_TO_PTR(args[0].u_obj);
-
-    // first check, whether
 
     for(uint8_t i = 0; i < ndarrays->len; i++) {
         if(!mp_obj_is_type(ndarrays->items[i], &ulab_ndarray_type)) {

--- a/code/ulab.c
+++ b/code/ulab.c
@@ -33,7 +33,7 @@
 #include "user/user.h"
 #include "utils/utils.h"
 
-#define ULAB_VERSION 6.0.8
+#define ULAB_VERSION 6.0.9
 #define xstr(s) str(s)
 #define str(s) #s
 

--- a/tests/2d/numpy/arange.py
+++ b/tests/2d/numpy/arange.py
@@ -17,3 +17,9 @@ try:
     np.arange(0, 10, 0)
 except ZeroDivisionError as e:
     print('ZeroDivisionError: ', e)
+
+# test for NAN length exception
+try:
+    np.arange(0, np.nan)
+except ValueError as e:
+    print('ValueError: ', e)

--- a/tests/2d/numpy/arange.py.exp
+++ b/tests/2d/numpy/arange.py.exp
@@ -19,3 +19,4 @@ array([2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0], dtype=float64)
 array([2.0, 5.0, 8.0], dtype=float64)
 array([], dtype=float64)
 ZeroDivisionError:  divide by zero
+ValueError:  arange: cannot compute length


### PR DESCRIPTION
Inputing `np.arange(0,np.nan)` crashes