### PR TITLE
ndarray_from_mp_obj correctly treats Booleans

### DIFF
--- a/code/ndarray.c
+++ b/code/ndarray.c
@@ -1730,6 +1730,12 @@ ndarray_obj_t *ndarray_from_mp_obj(mp_obj_t obj, uint8_t other_type) {
         ndarray = ndarray_new_linear_array(1, NDARRAY_FLOAT);
         mp_float_t *array = (mp_float_t *)ndarray->array;
         array[0] = mp_obj_get_float(obj);
+    } else if(mp_obj_is_bool(obj)) {
+        ndarray = ndarray_new_linear_array(1, NDARRAY_BOOLEAN);
+        uint8_t *array = (uint8_t *)ndarray->array;
+        if(obj == mp_const_true) {
+            *array = 1;
+        }
     } else if(mp_obj_is_type(obj, &ulab_ndarray_type)){
         return MP_OBJ_TO_PTR(obj);
     }

--- a/code/ulab.c
+++ b/code/ulab.c
@@ -33,7 +33,7 @@
 #include "user/user.h"
 #include "utils/utils.h"
 
-#define ULAB_VERSION 6.0.11
+#define ULAB_VERSION 6.0.12
 #define xstr(s) str(s)
 #define str(s) #s
 

--- a/docs/ulab-change-log.md
+++ b/docs/ulab-change-log.md
@@ -1,3 +1,9 @@
+Sun, 7 May 2023
+
+version 6.0.12
+
+    ndarray_from_mp_obj correctly treats Boolean arguments
+    
 Sat, 6 May 2023
 
 version 6.0.11


### PR DESCRIPTION
Fixes the issue mentioned in https://github.com/v923z/micropython-ulab/issues/589