### PR TITLE
fix fetching submodules (cp build process change)

### DIFF
--- a/build-cp.sh
+++ b/build-cp.sh
@@ -37,7 +37,7 @@ readlinkf_posix() {
 }
 NPROC=$(python3 -c 'import multiprocessing; print(multiprocessing.cpu_count())')
 HERE="$(dirname -- "$(readlinkf_posix -- "${0}")" )"
-[ -e circuitpython/py/py.mk ] || (git clone --branch main https://github.com/adafruit/circuitpython && cd circuitpython && make fetch-submodules && git submodule update --init lib/uzlib tools)
+[ -e circuitpython/py/py.mk ] || (git clone --branch main https://github.com/adafruit/circuitpython && cd circuitpython && make fetch-all-submodules && git submodule update --init lib/uzlib tools)
 rm -rf circuitpython/extmod/ulab; ln -s "$HERE" circuitpython/extmod/ulab
 dims=${1-2}
 make -C circuitpython/mpy-cross -j$NPROC


### PR DESCRIPTION
In https://github.com/adafruit/circuitpython/pull/8070 we changed the commands for fetching submodules.

from what I can see, fetch-all-submodules is what fetch-submodules was; this is more than strictly necessary but should be the smallest change to get ulab building again.

This is trying to fix the underlying the cause of the build failure seen in #625 