### PR TITLE
Fix -Wunused-variable diagnostic when !ULAB_SUPPORTS_COMPLEX

### DIFF
--- a/code/numpy/vector.c
+++ b/code/numpy/vector.c
@@ -840,9 +840,9 @@ mp_obj_t vector_sqrt(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args)
     mp_arg_val_t args[MP_ARRAY_SIZE(allowed_args)];
     mp_arg_parse_all(n_args, pos_args, kw_args, MP_ARRAY_SIZE(allowed_args), allowed_args, args);
 
-    mp_obj_t o_in = args[0].u_obj;
 
     #if ULAB_SUPPORTS_COMPLEX
+    mp_obj_t o_in = args[0].u_obj;
     uint8_t dtype = mp_obj_get_int(args[2].u_obj);
     if((dtype != NDARRAY_FLOAT) && (dtype != NDARRAY_COMPLEX)) {
         mp_raise_TypeError(translate("dtype must be float, or complex"));

--- a/code/ulab.c
+++ b/code/ulab.c
@@ -33,7 +33,7 @@
 #include "user/user.h"
 #include "utils/utils.h"
 
-#define ULAB_VERSION 6.3.3
+#define ULAB_VERSION 6.3.4
 #define xstr(s) str(s)
 #define str(s) #s
 

--- a/code/ulab.c
+++ b/code/ulab.c
@@ -33,7 +33,7 @@
 #include "user/user.h"
 #include "utils/utils.h"
 
-#define ULAB_VERSION 6.3.2
+#define ULAB_VERSION 6.3.3
 #define xstr(s) str(s)
 #define str(s) #s
 

--- a/docs/ulab-change-log.md
+++ b/docs/ulab-change-log.md
@@ -1,5 +1,17 @@
 Fri, 12 May 2023
 
+version 6.3.3
+
+    fix compile error when COMPLEX support not enabled
+
+version 6.3.2
+
+    fix out of bound read
+
+version 6.3.1
+
+    fix integer overflows
+
 version 6.3.0
 
     add bitwise operators

--- a/docs/ulab-change-log.md
+++ b/docs/ulab-change-log.md
@@ -1,8 +1,12 @@
 Fri, 12 May 2023
 
-version 6.3.3
+version 6.3.4
 
     fix compile error when COMPLEX support not enabled
+
+version 6.3.3
+
+    Polyval handles non-array as second argument (#601)
 
 version 6.3.2
 


### PR DESCRIPTION
`o_in` is only used in the SUPPORTS_COMPLEX case, so the variable definition needs to be moved accordingly.