### PR TITLE
numpy/vector.c: remove usage of fpclassify

### DIFF
--- a/code/numpy/vector.c
+++ b/code/numpy/vector.c
@@ -827,7 +827,7 @@ MP_DEFINE_CONST_FUN_OBJ_1(vector_sin_obj, vector_sin);
 //|
 
 static mp_float_t vector_sinc1(mp_float_t x) {
-    if (fpclassify(x) == FP_ZERO) {
+    if (x == MICROPY_FLOAT_CONST(0.)) {
         return MICROPY_FLOAT_CONST(1.);
     }
     x *= MP_PI;

--- a/tests/1d/numpy/universal_functions.py
+++ b/tests/1d/numpy/universal_functions.py
@@ -112,6 +112,13 @@ for i in range(len(x)):
     cmp_result.append(math.isclose(result[i], ref_result[i], rel_tol=1E-9, abs_tol=1E-9))
 print(cmp_result)
 
+result = np.sinc(x)
+ref_result = np.array([0.03935584386392389, -0.04359862862918773, 1.0, -0.04359862862918773, 0.03935584386392389])
+cmp_result = []
+for i in range(len(x)):
+    cmp_result.append(math.isclose(result[i], ref_result[i], rel_tol=1E-9, abs_tol=1E-9))
+print(cmp_result)
+
 result = (spy.special.erf(np.linspace(-3, 3, num=5)))
 ref_result = np.array([-0.9999779095030014, -0.9661051464753108, 0.0, 0.9661051464753108, 0.9999779095030014], dtype=np.float)
 cmp_result = []

--- a/tests/1d/numpy/universal_functions.py.exp
+++ b/tests/1d/numpy/universal_functions.py.exp
@@ -28,5 +28,6 @@ True
 [True, True, True, True, True]
 [True, True, True, True, True]
 [True, True, True, True, True]
+[True, True, True, True, True]
 [True, True, True, True]
 [True, True, True]


### PR DESCRIPTION
Fixes https://github.com/v923z/micropython-ulab/issues/635

Verified by re-compiling circuitpython with this change.