### PR TITLE
Remove the STATIC macro.

### DIFF
--- a/code/ndarray.c
+++ b/code/ndarray.c
@@ -917,7 +917,7 @@ ndarray_obj_t *ndarray_from_iterable(mp_obj_t obj, uint8_t dtype) {
     return ndarray;
 }
 
-STATIC uint8_t ndarray_init_helper(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static uint8_t ndarray_init_helper(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_, MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_rom_obj = MP_ROM_NONE } },
         { MP_QSTR_dtype, MP_ARG_KW_ONLY | MP_ARG_OBJ, {.u_rom_obj = MP_ROM_INT(NDARRAY_FLOAT) } },
@@ -940,7 +940,7 @@ STATIC uint8_t ndarray_init_helper(size_t n_args, const mp_obj_t *pos_args, mp_m
     return _dtype;
 }
 
-STATIC mp_obj_t ndarray_make_new_core(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args, mp_map_t *kw_args) {
+static mp_obj_t ndarray_make_new_core(const mp_obj_type_t *type, size_t n_args, size_t n_kw, const mp_obj_t *args, mp_map_t *kw_args) {
     uint8_t dtype = ndarray_init_helper(n_args, args, kw_args);
 
     if(mp_obj_is_type(args[0], &ulab_ndarray_type)) {

--- a/code/numpy/approx.c
+++ b/code/numpy/approx.c
@@ -47,7 +47,7 @@ ULAB_DEFINE_FLOAT_CONST(approx_trapz_dx, MICROPY_FLOAT_CONST(1.0), 0x3f800000UL,
 //|     ...
 //|
 
-STATIC mp_obj_t approx_interp(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t approx_interp(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_, MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_rom_obj = MP_ROM_NONE } },
         { MP_QSTR_, MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_rom_obj = MP_ROM_NONE } },
@@ -151,7 +151,7 @@ MP_DEFINE_CONST_FUN_OBJ_KW(approx_interp_obj, 2, approx_interp);
 //|     ...
 //|
 
-STATIC mp_obj_t approx_trapz(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t approx_trapz(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_, MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_rom_obj = MP_ROM_NONE } },
         { MP_QSTR_x, MP_ARG_OBJ, {.u_rom_obj = MP_ROM_NONE } },

--- a/code/numpy/fft/fft.c
+++ b/code/numpy/fft/fft.c
@@ -88,13 +88,13 @@ static mp_obj_t fft_ifft(size_t n_args, const mp_obj_t *args) {
 MP_DEFINE_CONST_FUN_OBJ_VAR_BETWEEN(fft_ifft_obj, 1, 2, fft_ifft);
 #endif
 
-STATIC const mp_rom_map_elem_t ulab_fft_globals_table[] = {
+static const mp_rom_map_elem_t ulab_fft_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_fft) },
     { MP_ROM_QSTR(MP_QSTR_fft), MP_ROM_PTR(&fft_fft_obj) },
     { MP_ROM_QSTR(MP_QSTR_ifft), MP_ROM_PTR(&fft_ifft_obj) },
 };
 
-STATIC MP_DEFINE_CONST_DICT(mp_module_ulab_fft_globals, ulab_fft_globals_table);
+static MP_DEFINE_CONST_DICT(mp_module_ulab_fft_globals, ulab_fft_globals_table);
 
 const mp_obj_module_t ulab_fft_module = {
     .base = { &mp_type_module },

--- a/code/numpy/linalg/linalg.c
+++ b/code/numpy/linalg/linalg.c
@@ -506,7 +506,7 @@ static mp_obj_t linalg_qr(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_
 MP_DEFINE_CONST_FUN_OBJ_KW(linalg_qr_obj, 1, linalg_qr);
 #endif
 
-STATIC const mp_rom_map_elem_t ulab_linalg_globals_table[] = {
+static const mp_rom_map_elem_t ulab_linalg_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_linalg) },
     #if ULAB_MAX_DIMS > 1
         #if ULAB_LINALG_HAS_CHOLESKY
@@ -530,7 +530,7 @@ STATIC const mp_rom_map_elem_t ulab_linalg_globals_table[] = {
     #endif
 };
 
-STATIC MP_DEFINE_CONST_DICT(mp_module_ulab_linalg_globals, ulab_linalg_globals_table);
+static MP_DEFINE_CONST_DICT(mp_module_ulab_linalg_globals, ulab_linalg_globals_table);
 
 const mp_obj_module_t ulab_linalg_module = {
     .base = { &mp_type_module },

--- a/code/scipy/optimize/optimize.c
+++ b/code/scipy/optimize/optimize.c
@@ -55,7 +55,7 @@ static mp_float_t optimize_python_call(const mp_obj_type_t *type, mp_obj_t fun, 
 //|     ...
 //|
 
-STATIC mp_obj_t optimize_bisect(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t optimize_bisect(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     // Simple bisection routine
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_, MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_rom_obj = MP_ROM_NONE } },
@@ -125,7 +125,7 @@ MP_DEFINE_CONST_FUN_OBJ_KW(optimize_bisect_obj, 3, optimize_bisect);
 //|     ...
 //|
 
-STATIC mp_obj_t optimize_fmin(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
+static mp_obj_t optimize_fmin(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw_args) {
     // downhill simplex method in 1D
     static const mp_arg_t allowed_args[] = {
         { MP_QSTR_, MP_ARG_REQUIRED | MP_ARG_OBJ, {.u_rom_obj = MP_ROM_NONE } },

--- a/code/ulab.c
+++ b/code/ulab.c
@@ -43,13 +43,13 @@
 #define ULAB_VERSION_STRING xstr(ULAB_VERSION) xstr(-) xstr(ULAB_MAX_DIMS) xstr(D)
 #endif
 
-STATIC MP_DEFINE_STR_OBJ(ulab_version_obj, ULAB_VERSION_STRING);
+static MP_DEFINE_STR_OBJ(ulab_version_obj, ULAB_VERSION_STRING);
 
 #ifdef ULAB_HASH
-STATIC MP_DEFINE_STR_OBJ(ulab_sha_obj, xstr(ULAB_HASH));
+static MP_DEFINE_STR_OBJ(ulab_sha_obj, xstr(ULAB_HASH));
 #endif
 
-STATIC const mp_rom_map_elem_t ulab_ndarray_locals_dict_table[] = {
+static const mp_rom_map_elem_t ulab_ndarray_locals_dict_table[] = {
     #if ULAB_MAX_DIMS > 1
         #if NDARRAY_HAS_RESHAPE
             { MP_ROM_QSTR(MP_QSTR_reshape), MP_ROM_PTR(&ndarray_reshape_obj) },
@@ -78,7 +78,7 @@ STATIC const mp_rom_map_elem_t ulab_ndarray_locals_dict_table[] = {
     #endif
 };
 
-STATIC MP_DEFINE_CONST_DICT(ulab_ndarray_locals_dict, ulab_ndarray_locals_dict_table);
+static MP_DEFINE_CONST_DICT(ulab_ndarray_locals_dict, ulab_ndarray_locals_dict_table);
 
 #if defined(MP_DEFINE_CONST_OBJ_TYPE)
 // MicroPython after-b41aaaa (Sept 19 2022).
@@ -192,7 +192,7 @@ const mp_obj_type_t ndarray_flatiter_type = {
 #endif
 #endif
 
-STATIC const mp_rom_map_elem_t ulab_globals_table[] = {
+static const mp_rom_map_elem_t ulab_globals_table[] = {
     { MP_ROM_QSTR(MP_QSTR___name__), MP_ROM_QSTR(MP_QSTR_ulab) },
     { MP_ROM_QSTR(MP_QSTR___version__), MP_ROM_PTR(&ulab_version_obj) },
     #ifdef ULAB_HASH
@@ -217,7 +217,7 @@ STATIC const mp_rom_map_elem_t ulab_globals_table[] = {
     #endif
 };
 
-STATIC MP_DEFINE_CONST_DICT (
+static MP_DEFINE_CONST_DICT (
     mp_module_ulab_globals,
     ulab_globals_table
 );

--- a/docs/manual/source/ulab-programming.rst
+++ b/docs/manual/source/ulab-programming.rst
@@ -896,7 +896,7 @@ the ``user`` module:
 
 .. code:: c
 
-   STATIC const mp_rom_map_elem_t ulab_user_globals_table[] = {
+   static const mp_rom_map_elem_t ulab_user_globals_table[] = {
        { MP_OBJ_NEW_QSTR(MP_QSTR___name__), MP_OBJ_NEW_QSTR(MP_QSTR_user) },
        { MP_OBJ_NEW_QSTR(MP_QSTR_square), (mp_obj_t)&user_square_obj },
    };

--- a/docs/ulab-programming.ipynb
+++ b/docs/ulab-programming.ipynb
@@ -718,7 +718,7 @@
     "Finally, we have to bind this function object in the globals table of the `user` module: \n",
     "\n",
     "```c\n",
-    "STATIC const mp_rom_map_elem_t ulab_user_globals_table[] = {\n",
+    "static const mp_rom_map_elem_t ulab_user_globals_table[] = {\n",
     "    { MP_OBJ_NEW_QSTR(MP_QSTR___name__), MP_OBJ_NEW_QSTR(MP_QSTR_user) },\n",
     "    { MP_OBJ_NEW_QSTR(MP_QSTR_square), (mp_obj_t)&user_square_obj },\n",
     "};\n",


### PR DESCRIPTION
Trying to get ahead of the changes proposed in micropython/micropython#13763.

I believe this change can be made safely ahead of MicroPython merging that PR, since `STATIC` should always resolve to `static` in production.

Methodology:

* `find -name *.c  | xargs sed -Ei "s/(^| )STATIC($| )/\1static\2/"` to automate replacement in .c files
* `grep -r STATIC` and manual fixes to the docs