### PR TITLE
fix loadtxt for the case, when built-in complexes are not supported

### DIFF
--- a/code/numpy/io/io.c
+++ b/code/numpy/io/io.c
@@ -239,7 +239,11 @@ MP_DEFINE_CONST_FUN_OBJ_1(io_load_obj, io_load);
 
 #if ULAB_NUMPY_HAS_LOADTXT
 static void io_assign_value(const char *clipboard, uint8_t len, ndarray_obj_t *ndarray, size_t *idx, uint8_t dtype) {
+    #if MICROPY_PY_BUILTINS_COMPLEX
     mp_obj_t value = mp_parse_num_decimal(clipboard, len, false, false, NULL);
+    #else
+    mp_obj_t value = mp_parse_num_float(clipboard, len, false, NULL);
+    #endif
     if(dtype != NDARRAY_FLOAT) {
         mp_float_t _value = mp_obj_get_float(value);
         value = mp_obj_new_int((int32_t)MICROPY_FLOAT_C_FUN(round)(_value));

--- a/code/ulab.c
+++ b/code/ulab.c
@@ -33,7 +33,7 @@
 #include "user/user.h"
 #include "utils/utils.h"
 
-#define ULAB_VERSION 6.5.1
+#define ULAB_VERSION 6.5.2
 #define xstr(s) str(s)
 #define str(s) #s
 

--- a/docs/ulab-change-log.md
+++ b/docs/ulab-change-log.md
@@ -1,3 +1,9 @@
+Wed, 6 Mar 2024
+
+version 6.5.2
+
+    allow loadtxt to parse numbers, even if built-in complexes are not supported
+
 Tue, 9 Jan 2024
 
 version 6.5.0


### PR DESCRIPTION
Fixes the issue mentioned in https://github.com/v923z/micropython-ulab/discussions/665.