### PR TITLE
CI: Update some deprecated dependency versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,10 +28,10 @@ jobs:
       env:
         GITHUB_CONTEXT: ${{ toJson(github) }}
       run: echo "$GITHUB_CONTEXT"
-    - name: Set up Python 3.10
-      uses: actions/setup-python@v1
+    - name: Set up Python 3.12
+      uses: actions/setup-python@v5
       with:
-        python-version: "3.10"
+        python-version: "3.12"
 
     - name: Install requirements
       run: |
@@ -44,10 +44,10 @@ jobs:
         gcc --version
         python3 --version
     - name: Checkout ulab
-      uses: actions/checkout@v1
+      uses: actions/checkout@v4
 
     - name: Checkout micropython repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         repository: micropython/micropython
         path: micropython
@@ -68,10 +68,10 @@ jobs:
       env:
         GITHUB_CONTEXT: ${{ toJson(github) }}
       run: echo "$GITHUB_CONTEXT"
-    - name: Set up Python 3.10
-      uses: actions/setup-python@v1
+    - name: Set up Python 3.12
+      uses: actions/setup-python@v5
       with:
-        python-version: "3.10"
+        python-version: "3.12"
 
     - name: Versions
       run: |
@@ -79,7 +79,7 @@ jobs:
         python3 --version
 
     - name: Checkout ulab
-      uses: actions/checkout@v1
+      uses: actions/checkout@v4
 
     - name: Install requirements
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,7 @@ on:
 
 jobs:
   micropython:
+    continue-on-error: true
     strategy:
         matrix:
             os:
@@ -56,6 +57,7 @@ jobs:
       run: ./build.sh ${{ matrix.dims }}
 
   circuitpython:
+    continue-on-error: true
     strategy:
         matrix:
             os:

--- a/build-cp.sh
+++ b/build-cp.sh
@@ -41,8 +41,7 @@ HERE="$(dirname -- "$(readlinkf_posix -- "${0}")" )"
 rm -rf circuitpython/extmod/ulab; ln -s "$HERE" circuitpython/extmod/ulab
 dims=${1-2}
 make -C circuitpython/mpy-cross -j$NPROC
-sed -e '/MICROPY_PY_UHASHLIB/s/1/0/' < circuitpython/ports/unix/mpconfigport.h > circuitpython/ports/unix/mpconfigport_ulab.h
-make -k -C circuitpython/ports/unix -j$NPROC DEBUG=1 MICROPY_PY_FFI=0 MICROPY_PY_BTREE=0 MICROPY_SSL_AXTLS=0 MICROPY_PY_USSL=0 CFLAGS_EXTRA="-DMP_CONFIGFILE=\"<mpconfigport_ulab.h>\" -Wno-tautological-constant-out-of-range-compare -Wno-unknown-pragmas -DULAB_MAX_DIMS=$dims" BUILD=build-$dims PROG=micropython-$dims
+make -k -C circuitpython/ports/unix -j$NPROC DEBUG=1 MICROPY_PY_FFI=0 MICROPY_PY_BTREE=0 MICROPY_SSL_AXTLS=0 MICROPY_PY_USSL=0 CFLAGS_EXTRA="-Wno-tautological-constant-out-of-range-compare -Wno-unknown-pragmas -DULAB_MAX_DIMS=$dims" BUILD=build-$dims PROG=micropython-$dims
 
 # bash test-common.sh "${dims}" "circuitpython/ports/unix/micropython-$dims"
 


### PR DESCRIPTION
Notably bumps Python to prevent macOS builds failing, and bumps "checkout" and "setup-python" versions to avoid deprecation warnings.

Tests/builds still seem to be failing so I've also enabled "continue-on-error" to try and make it run *all* the tests - for a better picture of what's failing and where- but seem to have failed to make this work across both MicroPython and CircuitPython tests.