### PR TITLE
Removed Pycom reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,6 @@ of the user manual.
 1. `MaixPy` https://github.com/sipeed/MaixPy
 1. `OpenMV` https://github.com/openmv/openmv
 1. `pimoroni-pico` https://github.com/pimoroni/pimoroni-pico
-3. `pycom` https://pycom.io/
 
 ## Compiling
 


### PR DESCRIPTION
UInfortunately Pycom is no longer a thing, removed from the platforms list.