### PR TITLE
Correct `"a[a < 5]"` in ulab-ndarray.ipynb

### DIFF
--- a/docs/ulab-ndarray.ipynb
+++ b/docs/ulab-ndarray.ipynb
@@ -3270,7 +3270,7 @@
      "output_type": "stream",
      "text": [
       "a:\t array([0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0], dtype=float)\n",
-      "a < 5:\t array([0.0, 1.0, 2.0, 3.0, 4.0], dtype=float)\n",
+      "a[a < 5]:\t array([0.0, 1.0, 2.0, 3.0, 4.0], dtype=float)\n",
       "\n",
       "\n"
      ]
@@ -3283,7 +3283,7 @@
     "\n",
     "a = np.array(range(9), dtype=np.float)\n",
     "print(\"a:\\t\", a)\n",
-    "print(\"a < 5:\\t\", a[a < 5])"
+    "print(\"a[a < 5]:\\t\", a[a < 5])"
    ]
   },
   {


### PR DESCRIPTION
The value of `a[a < 5]` should be referred to as `"a[a < 5]"`, not `"a < 5"`, because `a < 5` has a different value.