### PR TITLE
fix compilation error for complexes

### DIFF
--- a/code/ulab.c
+++ b/code/ulab.c
@@ -33,7 +33,7 @@
 #include "user/user.h"
 #include "utils/utils.h"
 
-#define ULAB_VERSION 6.6.0
+#define ULAB_VERSION 6.6.1
 #define xstr(s) str(s)
 #define str(s) #s
 

--- a/code/utils/utils.c
+++ b/code/utils/utils.c
@@ -286,7 +286,7 @@ mp_obj_t utils_spectrogram(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw
 
     uint8_t *array = (uint8_t *)in->array;
 
-    #if ULAB_FFT_IS_NUMPY_COMPATIBLE // ULAB_SUPPORTS_COMPLEX is automatically true
+    #if ULAB_FFT_IS_NUMPY_COMPATIBLE & ULAB_SUPPORTS_COMPLEX
     if(in->dtype == NDARRAY_COMPLEX) {
         uint8_t sz = 2 * sizeof(mp_float_t);
         for(size_t i = 0; i < len; i++) {

--- a/docs/ulab-change-log.md
+++ b/docs/ulab-change-log.md
@@ -1,3 +1,9 @@
+Sun, 24 Nov 2024
+
+version 6.6.1
+
+    fix compilation error, for complexes
+
 Wed, 9 Oct 2024
 
 version 6.6.0


### PR DESCRIPTION
Fixes a compilation error, when complexes are supported, but the FFT is not `numpy`-compatible.