### PR TITLE
Fixed signed number sorting Issue 744

### DIFF
--- a/code/numpy/numerical.c
+++ b/code/numpy/numerical.c
@@ -653,9 +653,13 @@ static mp_obj_t numerical_sort_helper(mp_obj_t oin, mp_obj_t axis, uint8_t inpla
 
     uint8_t *array = (uint8_t *)ndarray->array;
     if(ndarray->shape[ax]) {
-        if((ndarray->dtype == NDARRAY_UINT8) || (ndarray->dtype == NDARRAY_INT8)) {
+        if(ndarray->dtype == NDARRAY_INT8) {
+            HEAPSORT(ndarray, int8_t, array, shape, strides, ax, increment, ndarray->shape[ax]);
+        } else if(ndarray->dtype == NDARRAY_UINT8) {
             HEAPSORT(ndarray, uint8_t, array, shape, strides, ax, increment, ndarray->shape[ax]);
-        } else if((ndarray->dtype == NDARRAY_UINT16) || (ndarray->dtype == NDARRAY_INT16)) {
+        } else if(ndarray->dtype == NDARRAY_INT16) {
+            HEAPSORT(ndarray, int16_t, array, shape, strides, ax, increment, ndarray->shape[ax]);
+        } else if(ndarray->dtype == NDARRAY_UINT16) {
             HEAPSORT(ndarray, uint16_t, array, shape, strides, ax, increment, ndarray->shape[ax]);
         } else {
             HEAPSORT(ndarray, mp_float_t, array, shape, strides, ax, increment, ndarray->shape[ax]);
@@ -803,9 +807,13 @@ mp_obj_t numerical_argsort(size_t n_args, const mp_obj_t *pos_args, mp_map_t *kw
     iarray = indices->array;
 
     if(ndarray->shape[ax]) {
-        if((ndarray->dtype == NDARRAY_UINT8) || (ndarray->dtype == NDARRAY_INT8)) {
+        if(ndarray->dtype == NDARRAY_INT8) {
+            HEAP_ARGSORT(ndarray, int8_t, array, shape, strides, ax, increment, ndarray->shape[ax], iarray, istrides, iincrement);
+        } else if(ndarray->dtype == NDARRAY_UINT8) {
             HEAP_ARGSORT(ndarray, uint8_t, array, shape, strides, ax, increment, ndarray->shape[ax], iarray, istrides, iincrement);
-        } else if((ndarray->dtype == NDARRAY_UINT16) || (ndarray->dtype == NDARRAY_INT16)) {
+        } else if(ndarray->dtype == NDARRAY_INT16) {
+            HEAP_ARGSORT(ndarray, int16_t, array, shape, strides, ax, increment, ndarray->shape[ax], iarray, istrides, iincrement);
+        } else if(ndarray->dtype == NDARRAY_UINT16) {
             HEAP_ARGSORT(ndarray, uint16_t, array, shape, strides, ax, increment, ndarray->shape[ax], iarray, istrides, iincrement);
         } else {
             HEAP_ARGSORT(ndarray, mp_float_t, array, shape, strides, ax, increment, ndarray->shape[ax], iarray, istrides, iincrement);

--- a/code/ulab.c
+++ b/code/ulab.c
@@ -33,7 +33,7 @@
 #include "user/user.h"
 #include "utils/utils.h"
 
-#define ULAB_VERSION 6.12.0
+#define ULAB_VERSION 6.12.1
 #define xstr(s) str(s)
 #define str(s) #s
 

--- a/tests/1d/numpy/sort.py
+++ b/tests/1d/numpy/sort.py
@@ -1,0 +1,32 @@
+try:
+    from ulab import numpy as np
+except:
+    import numpy as np
+
+# sort and argsort over all dtypes, positive values
+for dtype in (np.uint8, np.int8, np.uint16, np.int16, np.float):
+    print()
+    a = np.array([], dtype=dtype)
+    print(np.sort(a, axis=0))
+    print(list(np.argsort(a, axis=0)))
+
+    a = np.array([4, 1, 3, 2], dtype=dtype)
+    print(np.sort(a, axis=0))
+    print(list(np.argsort(a, axis=0)))
+
+# sort and argsort with negative values for signed and float dtypes
+for dtype in (np.int8, np.int16, np.float):
+    print()
+    a = np.array([-3, 1, -2, 0], dtype=dtype)
+    print(np.sort(a, axis=0))
+    print(list(np.argsort(a, axis=0)))
+
+    a = np.array([5, -1, 3, -4, 2], dtype=dtype)
+    print(np.sort(a, axis=0))
+    print(list(np.argsort(a, axis=0)))
+
+# median with negative values for signed and float dtypes
+for dtype in (np.int8, np.int16, np.float):
+    print()
+    a = np.array([-5, -1, -3, -2, -4], dtype=dtype)
+    print(np.median(a))

--- a/tests/1d/numpy/sort.py.exp
+++ b/tests/1d/numpy/sort.py.exp
@@ -1,0 +1,46 @@
+
+array([], dtype=uint8)
+[]
+array([1, 2, 3, 4], dtype=uint8)
+[1, 3, 2, 0]
+
+array([], dtype=int8)
+[]
+array([1, 2, 3, 4], dtype=int8)
+[1, 3, 2, 0]
+
+array([], dtype=uint16)
+[]
+array([1, 2, 3, 4], dtype=uint16)
+[1, 3, 2, 0]
+
+array([], dtype=int16)
+[]
+array([1, 2, 3, 4], dtype=int16)
+[1, 3, 2, 0]
+
+array([], dtype=float64)
+[]
+array([1.0, 2.0, 3.0, 4.0], dtype=float64)
+[1, 3, 2, 0]
+
+array([-3, -2, 0, 1], dtype=int8)
+[0, 2, 3, 1]
+array([-4, -1, 2, 3, 5], dtype=int8)
+[3, 1, 4, 2, 0]
+
+array([-3, -2, 0, 1], dtype=int16)
+[0, 2, 3, 1]
+array([-4, -1, 2, 3, 5], dtype=int16)
+[3, 1, 4, 2, 0]
+
+array([-3.0, -2.0, 0.0, 1.0], dtype=float64)
+[0, 2, 3, 1]
+array([-4.0, -1.0, 2.0, 3.0, 5.0], dtype=float64)
+[3, 1, 4, 2, 0]
+
+-3.0
+
+-3.0
+
+-3.0

--- a/tests/2d/numpy/sort.py
+++ b/tests/2d/numpy/sort.py
@@ -3,16 +3,29 @@ try:
 except:
     import numpy as np
 
-dtypes = (np.uint8, np.int8, np.uint16, np.int16, np.float)
-
-for dtype in dtypes:
+# 2D sort and argsort over all dtypes, all axes
+for dtype in (np.uint8, np.int8, np.uint16, np.int16, np.float):
+    a = np.array([[4, 1, 3], [2, 5, 0]], dtype=dtype)
+    print(np.sort(a, axis=None))
+    print(np.sort(a, axis=0))
+    print(np.sort(a, axis=1))
+    print(np.argsort(a, axis=0))
     print()
-    a = np.array([], dtype=dtype)
-    print(np.sort(a, axis=0))
-    print(list(np.argsort(a, axis=0)))
 
-    a = np.array([4, 1, 3, 2], dtype=dtype)
+# 2D sort with negative values for signed and float dtypes, axis=0 and axis=1
+for dtype in (np.int8, np.int16, np.float):
+    a = np.array([[-3, 1], [2, -4], [-1, 3]], dtype=dtype)
     print(np.sort(a, axis=0))
-    print(list(np.argsort(a, axis=0)))
+    a = np.array([[3, -1, 2], [-4, 5, -2]], dtype=dtype)
+    print(np.sort(a, axis=1))
+    print()
+
+# 2D median with negative values for signed and float dtypes, axis=0 and axis=1
+for dtype in (np.int16, np.float):
+    a = np.array([[-3, 1, 2], [0, -4, 1], [2, 3, -1]], dtype=dtype)
+    print(np.median(a, axis=0))
+    print(np.median(a, axis=1))
+    print()
+
 
 

--- a/tests/2d/numpy/sort.py.exp
+++ b/tests/2d/numpy/sort.py.exp
@@ -1,25 +1,64 @@
+array([0, 1, 2, 3, 4, 5], dtype=uint8)
+array([[2, 1, 0],
+       [4, 5, 3]], dtype=uint8)
+array([[1, 3, 4],
+       [0, 2, 5]], dtype=uint8)
+array([[1, 0, 1],
+       [0, 1, 0]], dtype=uint16)
 
-array([], dtype=uint8)
-[]
-array([1, 2, 3, 4], dtype=uint8)
-[1, 3, 2, 0]
+array([0, 1, 2, 3, 4, 5], dtype=int8)
+array([[2, 1, 0],
+       [4, 5, 3]], dtype=int8)
+array([[1, 3, 4],
+       [0, 2, 5]], dtype=int8)
+array([[1, 0, 1],
+       [0, 1, 0]], dtype=uint16)
 
-array([], dtype=int8)
-[]
-array([1, 2, 3, 4], dtype=int8)
-[1, 3, 2, 0]
+array([0, 1, 2, 3, 4, 5], dtype=uint16)
+array([[2, 1, 0],
+       [4, 5, 3]], dtype=uint16)
+array([[1, 3, 4],
+       [0, 2, 5]], dtype=uint16)
+array([[1, 0, 1],
+       [0, 1, 0]], dtype=uint16)
 
-array([], dtype=uint16)
-[]
-array([1, 2, 3, 4], dtype=uint16)
-[1, 3, 2, 0]
+array([0, 1, 2, 3, 4, 5], dtype=int16)
+array([[2, 1, 0],
+       [4, 5, 3]], dtype=int16)
+array([[1, 3, 4],
+       [0, 2, 5]], dtype=int16)
+array([[1, 0, 1],
+       [0, 1, 0]], dtype=uint16)
 
-array([], dtype=int16)
-[]
-array([1, 2, 3, 4], dtype=int16)
-[1, 3, 2, 0]
+array([0.0, 1.0, 2.0, 3.0, 4.0, 5.0], dtype=float64)
+array([[2.0, 1.0, 0.0],
+       [4.0, 5.0, 3.0]], dtype=float64)
+array([[1.0, 3.0, 4.0],
+       [0.0, 2.0, 5.0]], dtype=float64)
+array([[1, 0, 1],
+       [0, 1, 0]], dtype=uint16)
 
-array([], dtype=float64)
-[]
-array([1.0, 2.0, 3.0, 4.0], dtype=float64)
-[1, 3, 2, 0]
+array([[-3, -4],
+       [-1, 1],
+       [2, 3]], dtype=int8)
+array([[-1, 2, 3],
+       [-4, -2, 5]], dtype=int8)
+
+array([[-3, -4],
+       [-1, 1],
+       [2, 3]], dtype=int16)
+array([[-1, 2, 3],
+       [-4, -2, 5]], dtype=int16)
+
+array([[-3.0, -4.0],
+       [-1.0, 1.0],
+       [2.0, 3.0]], dtype=float64)
+array([[-1.0, 2.0, 3.0],
+       [-4.0, -2.0, 5.0]], dtype=float64)
+
+array([0.0, 1.0, 1.0], dtype=float64)
+array([1.0, 0.0, 2.0], dtype=float64)
+
+array([0.0, 1.0, 1.0], dtype=float64)
+array([1.0, 0.0, 2.0], dtype=float64)
+


### PR DESCRIPTION
Fixes #744

Made the adjustments I proposed in the issue report. 

Moved the current tests to the 1D dimensions (simular how other tests handle this)
Added more tests for the 2D dimension
Added tests for signed values

After adding the tests I noticed argsort had the same issue, and fixed it the same way.